### PR TITLE
Consolidate parentheses in calls

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-import(Config)
+import Config
 
 env = config_env()
 import_config("#{env}.exs")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,3 @@
-import(Config)
+import Config
 
 config(:onigumo, :http_client, HTTPoisonMock)

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -6,9 +6,9 @@ defmodule OnigumoTest do
 
   @filename "body.html"
 
-  setup :verify_on_exit!
+  setup(:verify_on_exit!)
 
-  test "download" do
+  test("download") do
     expect(
       HTTPoisonMock,
       :get!,
@@ -19,7 +19,7 @@ defmodule OnigumoTest do
         }
       end
     )
-    assert :ok = Onigumo.download()
-    assert "hello\n" = File.read!(@filename)
+    assert(:ok = Onigumo.download())
+    assert("hello\n" = File.read!(@filename))
   end
 end


### PR DESCRIPTION
* Use parentheses for function calls. That includes `import_config`,
  `config`, `test`, `assert`, `setup` or `defmock`.
* Do not use parentheses for [Kernel](https://hexdocs.pm/elixir/Kernel.html) calls and [special forms](https://hexdocs.pm/elixir/Kernel.SpecialForms.html). That includes `def`,
  `defp`, `defmodule`, `use` or `import`.

This makes the code consistent, yet avoiding strange syntax like `defmodule(…)`.

I am not sure what a good solution is. Maybe keeping asserts, test definitions and config calls without parentheses would be more readable. Yet I’d like to keep the number of exception as low as possible, sticking only to _Kernel_.