### PR TITLE
Remove unused doctest

### DIFF
--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -2,8 +2,6 @@ defmodule OnigumoTest do
   use ExUnit.Case
   import Mox
   
-  doctest Onigumo
-
   @filename "body.html"
 
   setup :verify_on_exit!
@@ -21,5 +19,6 @@ defmodule OnigumoTest do
     )
     assert :ok = Onigumo.download()
     assert "hello\n" = File.read!(@filename)
+    
   end
 end


### PR DESCRIPTION
We do not have any test cases in our documentation strings. Thus `doctest` is not used and not needed. See [ExUnit.DocTest](https://hexdocs.pm/ex_unit/ExUnit.DocTest.html#doctest/2).