### PR TITLE
Test download of multiple URLs

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -13,7 +13,7 @@ defmodule Onigumo do
   end
 
   def save_urls_contents(http) do
-    load_urls()
+    load_urls(@input_filename)
     |> download(http)
   end
 
@@ -30,8 +30,8 @@ defmodule Onigumo do
     File.write!(@output_filename, body)
   end
 
-  def load_urls() do
-    File.stream!(@input_filename, [:read], :line)
+  def load_urls(filepath) do
+    File.stream!(filepath, [:read], :line)
     |> Enum.map(&String.trim_trailing/1)
   end
 

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -9,19 +9,24 @@ defmodule Onigumo do
 
   def main() do
     HTTPoison.start()
-    http = http_client()
+    save_URLs_contents(@input_filename, @output_filename)
 
-    load_urls(@input_filename)
-    |> Enum.map(&download(http, &1))
   end
 
-  def download(http_client, url) do
+  def save_URLs_contents(input_file, output_file) do
+    http = http_client()
+
+    load_urls(input_file)
+    |> Enum.map(&download(http, &1, output_file))
+  end
+
+  def download(http_client, url, output_file) do
     %HTTPoison.Response{
       status_code: 200,
       body: body
     } = http_client.get!(url)
 
-    File.write!(@output_filename, body)
+    File.write!(output_file, body, [:append])
   end
 
   def load_urls(filepath) do

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -3,7 +3,9 @@ defmodule Onigumo do
   Web scraper
   """
   @input_filename "urls.txt"
+  def input_filename, do: @input_filename
   @output_filename "body.html"
+  def output_filename, do: @output_filename
 
   def main() do
     HTTPoison.start()

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -9,29 +9,29 @@ defmodule Onigumo do
     HTTPoison.start()
     http = http_client()
 
-    save_urls_contents(http, @input_filename, @output_filename)
+    save_urls_contents(http)
   end
 
-  def save_urls_contents(http, input_file, output_file) do
-    load_urls(input_file)
-    |> download(http, output_file)
+  def save_urls_contents(http) do
+    load_urls()
+    |> download(http)
   end
 
-  def download(urls, http_client, output_file) when is_list(urls) do
-    Enum.map(urls, &download(&1, http_client, output_file))
+  def download(urls, http_client) when is_list(urls) do
+    Enum.map(urls, &download(&1, http_client))
   end
 
-  def download(url, http_client, output_file) do
+  def download(url, http_client) do
     %HTTPoison.Response{
       status_code: 200,
       body: body
     } = http_client.get!(url)
 
-    File.write!(output_file, body)
+    File.write!(@output_filename, body)
   end
 
-  def load_urls(filepath) do
-    File.stream!(filepath, [:read], :line)
+  def load_urls() do
+    File.stream!(@input_filename, [:read], :line)
     |> Enum.map(&String.trim_trailing/1)
   end
 

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -3,27 +3,30 @@ defmodule Onigumo do
   Web scraper
   """
   @input_filename "urls.txt"
-  def input_filename, do: @input_filename
   @output_filename "body.html"
-  def output_filename, do: @output_filename
 
   def main() do
     HTTPoison.start()
-    save_urls_contents(@input_filename, @output_filename)
-  end
-
-  def save_urls_contents(input_file, output_file) do
     http = http_client()
 
-    load_urls(input_file)
-    |> Enum.map(&download(http, &1, output_file))
+    save_urls_contents(http, @input_filename, @output_filename)
   end
 
-  def download(http_client, url, output_file) do
+  def save_urls_contents(http, input_file, output_file) do
+    load_urls(input_file)
+    |> download(http, output_file)
+  end
+
+  def download(urls, http_client, output_file) when is_list(urls) do
+    Enum.map(urls, &download(&1, http, output_file))
+  end
+
+  def download(url, http_client, output_file) do
     %HTTPoison.Response{
       status_code: 200,
       body: body
     } = http_client.get!(url)
+    IO.puts(body)
 
     File.write!(output_file, body, [:append])
   end

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -26,7 +26,6 @@ defmodule Onigumo do
       status_code: 200,
       body: body
     } = http_client.get!(url)
-    IO.puts(body)
 
     File.write!(output_file, body)
   end

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -13,15 +13,15 @@ defmodule Onigumo do
   end
 
   def download(http_client) do
-    load_urls(@input_filename)
-    |> download(http_client)
+    urls = load_urls(@input_filename)
+    download(http_client, urls)
   end
 
-  def download(urls, http_client) when is_list(urls) do
-    Enum.map(urls, &download(&1, http_client))
+  def download(http_client, urls) when is_list(urls) do
+    Enum.map(urls, &download(http_client, &1))
   end
 
-  def download(url, http_client) when is_bitstring(url) do
+  def download(http_client, url) when is_bitstring(url) do
     %HTTPoison.Response{
       status_code: 200,
       body: body

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -28,7 +28,7 @@ defmodule Onigumo do
     } = http_client.get!(url)
     IO.puts(body)
 
-    File.write!(output_file, body, [:append])
+    File.write!(output_file, body)
   end
 
   def load_urls(filepath) do

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -9,10 +9,10 @@ defmodule Onigumo do
 
   def main() do
     HTTPoison.start()
-    save_URLs_contents(@input_filename, @output_filename)
+    save_urls_contents(@input_filename, @output_filename)
   end
 
-  def save_URLs_contents(input_file, output_file) do
+  def save_urls_contents(input_file, output_file) do
     http = http_client()
 
     load_urls(input_file)

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -9,19 +9,19 @@ defmodule Onigumo do
     HTTPoison.start()
     http = http_client()
 
-    save_urls_contents(http)
+    download(http)
   end
 
-  def save_urls_contents(http) do
+  def download(http_client) do
     load_urls(@input_filename)
-    |> download(http)
+    |> download(http_client)
   end
 
   def download(urls, http_client) when is_list(urls) do
     Enum.map(urls, &download(&1, http_client))
   end
 
-  def download(url, http_client) do
+  def download(url, http_client) when is_bitstring(url) do
     %HTTPoison.Response{
       status_code: 200,
       body: body

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -10,7 +10,6 @@ defmodule Onigumo do
   def main() do
     HTTPoison.start()
     save_URLs_contents(@input_filename, @output_filename)
-
   end
 
   def save_URLs_contents(input_file, output_file) do

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -21,7 +21,7 @@ defmodule Onigumo do
     Enum.map(urls, &download(http_client, &1))
   end
 
-  def download(http_client, url) when is_bitstring(url) do
+  def download(http_client, url) when is_binary(url) do
     %HTTPoison.Response{
       status_code: 200,
       body: body

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -18,7 +18,7 @@ defmodule Onigumo do
   end
 
   def download(urls, http_client, output_file) when is_list(urls) do
-    Enum.map(urls, &download(&1, http, output_file))
+    Enum.map(urls, &download(&1, http_client, output_file))
   end
 
   def download(url, http_client, output_file) do

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -17,13 +17,13 @@ defmodule OnigumoTest do
       fn url ->
         %HTTPoison.Response{
           status_code: 200,
-          body: "Body from: #{url}\n"
+          body: "Body from: #{url}"
         }
       end
     )
 
     assert(:ok == Onigumo.download(HTTPoisonMock, @url_1))
-    assert("Body from: #{@url_1}\n" == File.read!(@filename))
+    assert("Body from: #{@url_1}" == File.read!(@filename))
   end
 
 
@@ -35,14 +35,14 @@ defmodule OnigumoTest do
       fn url ->
         %HTTPoison.Response{
           status_code: 200,
-          body: "Body from: #{url}\n"
+          body: "Body from: #{url}"
         }
       end
     )
 
     urls = [@url_1, @url_2]
     assert([:ok, :ok] == Onigumo.download(HTTPoisonMock, urls))
-    assert("Body from: #{@url_2}\n" == File.read!(@filename))
+    assert("Body from: #{@url_2}" == File.read!(@filename))
   end
 
   test("download URLs from the input file") do
@@ -53,7 +53,7 @@ defmodule OnigumoTest do
       fn url ->
         %HTTPoison.Response{
           status_code: 200,
-          body: "Body from: #{url}\n"
+          body: "Body from: #{url}"
         }
       end
     )

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -10,7 +10,7 @@ defmodule OnigumoTest do
 
   setup(:verify_on_exit!)
 
-  test("download one URL") do
+  test("download a single URL") do
     expect(
       HTTPoisonMock,
       :get!,
@@ -45,7 +45,7 @@ defmodule OnigumoTest do
     assert("Body from: #{@url_2}\n" == File.read!(@output_filename))
   end
 
-  test("integration test") do
+  test("download URLs from the input file") do
     expect(
       HTTPoisonMock,
       :get!,
@@ -69,7 +69,7 @@ defmodule OnigumoTest do
   end
 
   @tag :tmp_dir
-  test("load one URL from file", %{tmp_dir: tmp_dir}) do
+  test("load a single URL from a file", %{tmp_dir: tmp_dir}) do
     filepath = Path.join(tmp_dir, @input_filename)
     content = "#{@url_1}\n"
     File.write!(filepath, content)
@@ -79,7 +79,7 @@ defmodule OnigumoTest do
   end
 
   @tag :tmp_dir
-  test("load two URLs from file", %{tmp_dir: tmp_dir}) do
+  test("load multiple URLs from a file", %{tmp_dir: tmp_dir}) do
     filepath = Path.join(tmp_dir, @input_filename)
     content = "#{@url_1}\n#{@url_2}\n"
     File.write!(filepath, content)

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -22,7 +22,7 @@ defmodule OnigumoTest do
       end
     )
 
-    assert(:ok == Onigumo.download(@url_1, HTTPoisonMock))
+    assert(:ok == Onigumo.download(HTTPoisonMock, @url_1))
     assert("Body from: #{@url_1}\n" == File.read!(@output_filename))
   end
 
@@ -41,7 +41,7 @@ defmodule OnigumoTest do
     )
 
     urls = [@url_1, @url_2]
-    assert([:ok, :ok] == Onigumo.download(urls, HTTPoisonMock))
+    assert([:ok, :ok] == Onigumo.download(HTTPoisonMock, urls))
     assert("Body from: #{@url_2}\n" == File.read!(@output_filename))
   end
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -68,19 +68,23 @@ defmodule OnigumoTest do
     assert(expected == File.read!(@output_filename))
   end
 
-  test("load one URL from file") do
+  @tag :tmp_dir
+  test("load one URL from file", %{tmp_dir: tmp_dir}) do
+    filepath = Path.join(tmp_dir, @input_filename)
     content = "#{@url_1}\n"
-    File.write!(@input_filename, content)
+    File.write!(filepath, content)
 
     expected = [@url_1]
-    assert(expected == Onigumo.load_urls())
+    assert(expected == Onigumo.load_urls(filepath))
   end
 
-  test("load two URLs from file") do
+  @tag :tmp_dir
+  test("load two URLs from file", %{tmp_dir: tmp_dir}) do
+    filepath = Path.join(tmp_dir, @input_filename)
     content = "#{@url_1}\n#{@url_2}\n"
-    File.write!(@input_filename, content)
+    File.write!(filepath, content)
 
     expected = [@url_1, @url_2]
-    assert(expected == Onigumo.load_urls())
+    assert(expected == Onigumo.load_urls(filepath))
   end
 end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -17,17 +17,39 @@ defmodule OnigumoTest do
       fn url ->
         %HTTPoison.Response{
           status_code: 200,
-          body: "Body from: #{url}"
+          body: "Body from: #{url}\n"
         }
       end
     )
 
-    assert(:ok == Onigumo.download(HTTPoisonMock, @url_1, output_file))
-    assert("Body from: #{@url_1}" == File.read!(output_file))
+    assert(:ok == Onigumo.download(@url_1, HTTPoisonMock, output_file))
+    assert("Body from: #{@url_1}\n" == File.read!(output_file))
+  end
+
+
+  @tag :tmp_dir
+  test("download multiple URLs", %{tmp_dir: tmp_dir}) do
+    output_file = Path.join(tmp_dir, "outputfile")
+
+    expect(
+      HTTPoisonMock,
+      :get!,
+      2,
+      fn url ->
+        %HTTPoison.Response{
+          status_code: 200,
+          body: "Body from: #{url}\n"
+        }
+      end
+    )
+
+    urls = [@url_1, @url_2]
+    assert([:ok, :ok] == Onigumo.download(urls, HTTPoisonMock, output_file))
+    assert("Body from: #{@url_2}\n" == File.read!(output_file))
   end
 
   @tag :tmp_dir
-  test("download multiply URLs", %{tmp_dir: tmp_dir}) do
+  test("integration test", %{tmp_dir: tmp_dir}) do
     output_file = Path.join(tmp_dir, "outputfile")
     input_file = Path.join(tmp_dir, "inputfile")
 
@@ -45,10 +67,10 @@ defmodule OnigumoTest do
 
     content = "#{@url_1}\n#{@url_2}\n"
     File.write!(input_file, content)
-    expected = "Body from: #{@url_1}\nBody from: #{@url_2}\n"
+    expected = "Body from: #{@url_2}\n"
     # load urls from urls_file
     # read result from some test file
-    Onigumo.save_urls_contents(input_file, output_file)
+    Onigumo.save_urls_contents(HTTPoisonMock, input_file, output_file)
 
     assert(expected == File.read!(output_file))
   end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -43,7 +43,8 @@ defmodule OnigumoTest do
       end
     )
 
-    assert([:ok, :ok] == Onigumo.download(HTTPoisonMock, @urls))
+    responses = Enum.map(@urls, fn _ -> :ok end)
+    assert(responses == Onigumo.download(HTTPoisonMock, @urls))
     last_url = Enum.at(@urls, -1)
     assert("Body from: #{last_url}" == File.read!(@filename))
   end
@@ -64,10 +65,11 @@ defmodule OnigumoTest do
     content = Enum.map(@urls, &(&1 <> " \n")) |> Enum.join()
     File.write!(@testfile_with_urls, content)
 
+    responses = Enum.map(@urls, fn _ -> :ok end)
+    assert(responses == Onigumo.download(HTTPoisonMock))
+
     last_url = Enum.at(@urls, -1)
     expected = "Body from: #{last_url}"
-    Onigumo.download(HTTPoisonMock)
-
     assert(expected == File.read!(@filename))
   end
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -48,7 +48,7 @@ defmodule OnigumoTest do
     expected = "Body from: #{@url_1}\nBody from: #{@url_2}\n"
     # load urls from urls_file
     # read result from some test file
-    Onigumo.save_URLs_contents(input_file, output_file)
+    Onigumo.save_urls_contents(input_file, output_file)
 
     assert(expected == File.read!(output_file))
   end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -72,7 +72,7 @@ defmodule OnigumoTest do
   end
 
   @tag :tmp_dir
-  test("load a single URL from a file", %{tmp_dir: tmp_dir}) do
+  test("load URL from file", %{tmp_dir: tmp_dir}) do
     url = Enum.at(@urls, 0)
 
     filepath = Path.join(tmp_dir, @testfile_with_urls)
@@ -81,14 +81,5 @@ defmodule OnigumoTest do
 
     expected = [url]
     assert(expected == Onigumo.load_urls(filepath))
-  end
-
-  @tag :tmp_dir
-  test("load multiple URLs from a file", %{tmp_dir: tmp_dir}) do
-    filepath = Path.join(tmp_dir, @testfile_with_urls)
-    content = Enum.map(@urls, &(&1 <> " \n")) |> Enum.join()
-    File.write!(filepath, content)
-
-    assert(@urls == Onigumo.load_urls(filepath))
   end
 end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -37,13 +37,15 @@ defmodule OnigumoTest do
         }
       end
     )
-    filepath = Path.join(tmp_dir, @testfile_with_urls)
+    urls_file = Path.join(tmp_dir, @testfile_with_urls)
     content = "#{@url_1}\n#{@url_2}\n"
-    File.write!(filepath, content)
+    File.write!(Onigumo.input_filename, content)
     expected = "Body from: #{@url_1}\nBody from: #{@url_2}\n"
-    Onigumo.main(filepath)
+    # load urls from urls_file
+    # read result from some test file
+    Onigumo.main()
 
-    assert(expected == File.read!(Onigumo.@output_filename))
+    assert(expected == File.read!(Onigumo.output_filename))
   end
 
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -82,4 +82,5 @@ defmodule OnigumoTest do
     expected = [url]
     assert(expected == Onigumo.load_urls(filepath))
   end
+
 end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -27,7 +27,7 @@ defmodule OnigumoTest do
 
   @tag :tmp_dir
   test("download multiple URLs", %{tmp_dir: tmp_dir}) do
-    expect(HTTPoisonMock,:get!,length(@urls), &get!/1)
+    expect(HTTPoisonMock, :get!, length(@urls), &get!/1)
 
     path = Path.join(tmp_dir, @output_path)
     responses = Enum.map(@urls, fn _ -> :ok end)
@@ -41,8 +41,7 @@ defmodule OnigumoTest do
 
   @tag :tmp_dir
   test("download URLs from the input file", %{tmp_dir: tmp_dir}) do
-    expect(
-      HTTPoisonMock,:get!,length(@urls), &get!/1)
+    expect(HTTPoisonMock, :get!, length(@urls), &get!/1)
 
     content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
     File.write!(@input_path, content)

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -9,7 +9,9 @@ defmodule OnigumoTest do
 
   setup(:verify_on_exit!)
 
-  test("download one URL") do
+  @tag :tmp_dir
+  test("download one URL", %{tmp_dir: tmp_dir}) do
+    output_file = Path.join(tmp_dir, "outputfile")
     expect(
       HTTPoisonMock,
       :get!,
@@ -21,12 +23,14 @@ defmodule OnigumoTest do
       end
     )
 
-    assert(:ok == Onigumo.download(HTTPoisonMock, @url_1))
-    assert("Body from: #{@url_1}" == File.read!(@filename))
+    assert(:ok == Onigumo.download(HTTPoisonMock, @url_1, output_file))
+    assert("Body from: #{@url_1}" == File.read!(output_file))
   end
 
   @tag :tmp_dir
   test("download multiply URLs", %{tmp_dir: tmp_dir}) do
+    output_file = Path.join(tmp_dir, "outputfile")
+    input_file = Path.join(tmp_dir, "inputfile")
     expect(
       HTTPoisonMock,
       :get!,
@@ -34,19 +38,19 @@ defmodule OnigumoTest do
       fn url ->
         %HTTPoison.Response{
           status_code: 200,
-          body: "Body from: #{url}"
+          body: "Body from: #{url}\n"
         }
       end
     )
-    urls_file = Path.join(tmp_dir, @testfile_with_urls)
+
     content = "#{@url_1}\n#{@url_2}\n"
-    File.write!(Onigumo.input_filename, content)
+    File.write!(input_file, content)
     expected = "Body from: #{@url_1}\nBody from: #{@url_2}\n"
     # load urls from urls_file
     # read result from some test file
-    Onigumo.main()
+    Onigumo.save_URLs_contents(input_file, output_file)
 
-    assert(expected == File.read!(Onigumo.output_filename))
+    assert(expected == File.read!(output_file))
   end
 
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -2,8 +2,8 @@ defmodule OnigumoTest do
   use ExUnit.Case
   import Mox
 
-  @url_1 "http://onigumo.org/hello.html"
-  @url_2 "http://onigumo.org/bye.html"
+  @url_1 "https://onigumo.local/hello.html"
+  @url_2 "https://onigumo.local/bye.html"
 
   @input_filename "urls.txt"
   @output_filename "body.html"

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -5,12 +5,12 @@ defmodule OnigumoTest do
   @url_1 "http://onigumo.org/hello.html"
   @url_2 "http://onigumo.org/bye.html"
 
+  @input_filename "urls.txt"
+  @output_filename "body.html"
+
   setup(:verify_on_exit!)
 
-  @tag :tmp_dir
-  test("download one URL", %{tmp_dir: tmp_dir}) do
-    output_file = Path.join(tmp_dir, "outputfile")
-
+  test("download one URL") do
     expect(
       HTTPoisonMock,
       :get!,
@@ -22,15 +22,12 @@ defmodule OnigumoTest do
       end
     )
 
-    assert(:ok == Onigumo.download(@url_1, HTTPoisonMock, output_file))
-    assert("Body from: #{@url_1}\n" == File.read!(output_file))
+    assert(:ok == Onigumo.download(@url_1, HTTPoisonMock))
+    assert("Body from: #{@url_1}\n" == File.read!(@output_filename))
   end
 
 
-  @tag :tmp_dir
-  test("download multiple URLs", %{tmp_dir: tmp_dir}) do
-    output_file = Path.join(tmp_dir, "outputfile")
-
+  test("download multiple URLs") do
     expect(
       HTTPoisonMock,
       :get!,
@@ -44,15 +41,11 @@ defmodule OnigumoTest do
     )
 
     urls = [@url_1, @url_2]
-    assert([:ok, :ok] == Onigumo.download(urls, HTTPoisonMock, output_file))
-    assert("Body from: #{@url_2}\n" == File.read!(output_file))
+    assert([:ok, :ok] == Onigumo.download(urls, HTTPoisonMock))
+    assert("Body from: #{@url_2}\n" == File.read!(@output_filename))
   end
 
-  @tag :tmp_dir
-  test("integration test", %{tmp_dir: tmp_dir}) do
-    output_file = Path.join(tmp_dir, "outputfile")
-    input_file = Path.join(tmp_dir, "inputfile")
-
+  test("integration test") do
     expect(
       HTTPoisonMock,
       :get!,
@@ -66,32 +59,28 @@ defmodule OnigumoTest do
     )
 
     content = "#{@url_1}\n#{@url_2}\n"
-    File.write!(input_file, content)
+    File.write!(@input_filename, content)
     expected = "Body from: #{@url_2}\n"
     # load urls from urls_file
     # read result from some test file
-    Onigumo.save_urls_contents(HTTPoisonMock, input_file, output_file)
+    Onigumo.save_urls_contents(HTTPoisonMock)
 
-    assert(expected == File.read!(output_file))
+    assert(expected == File.read!(@output_filename))
   end
 
-  @tag :tmp_dir
-  test("load one URL from file", %{tmp_dir: tmp_dir}) do
-    filepath = Path.join(tmp_dir, "input_file")
+  test("load one URL from file") do
     content = "#{@url_1}\n"
-    File.write!(filepath, content)
+    File.write!(@input_filename, content)
 
     expected = [@url_1]
-    assert(expected == Onigumo.load_urls(filepath))
+    assert(expected == Onigumo.load_urls())
   end
 
-  @tag :tmp_dir
-  test("load two URLs from file", %{tmp_dir: tmp_dir}) do
-    filepath = Path.join(tmp_dir, "input_file")
+  test("load two URLs from file") do
     content = "#{@url_1}\n#{@url_2}\n"
-    File.write!(filepath, content)
+    File.write!(@input_filename, content)
 
     expected = [@url_1, @url_2]
-    assert(expected == Onigumo.load_urls(filepath))
+    assert(expected == Onigumo.load_urls())
   end
 end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -78,7 +78,7 @@ defmodule OnigumoTest do
     url = Enum.at(@urls, 0)
 
     filepath = Path.join(tmp_dir, @testfile_with_urls)
-    content = url <> "\n"
+    content = url <> " \n"
     File.write!(filepath, content)
 
     expected = [url]

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -30,6 +30,7 @@ defmodule OnigumoTest do
     expect(
       HTTPoisonMock,
       :get!,
+      2,
       fn url ->
         %HTTPoison.Response{
           status_code: 200,

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -12,6 +12,7 @@ defmodule OnigumoTest do
   @tag :tmp_dir
   test("download one URL", %{tmp_dir: tmp_dir}) do
     output_file = Path.join(tmp_dir, "outputfile")
+
     expect(
       HTTPoisonMock,
       :get!,
@@ -31,6 +32,7 @@ defmodule OnigumoTest do
   test("download multiply URLs", %{tmp_dir: tmp_dir}) do
     output_file = Path.join(tmp_dir, "outputfile")
     input_file = Path.join(tmp_dir, "inputfile")
+
     expect(
       HTTPoisonMock,
       :get!,
@@ -53,7 +55,6 @@ defmodule OnigumoTest do
     assert(expected == File.read!(output_file))
   end
 
-
   @tag :tmp_dir
   test("load one URL from file", %{tmp_dir: tmp_dir}) do
     filepath = Path.join(tmp_dir, @testfile_with_urls)
@@ -64,7 +65,6 @@ defmodule OnigumoTest do
     assert(expected == Onigumo.load_urls(filepath))
   end
 
-
   @tag :tmp_dir
   test("load two URLs from file", %{tmp_dir: tmp_dir}) do
     filepath = Path.join(tmp_dir, @testfile_with_urls)
@@ -74,5 +74,4 @@ defmodule OnigumoTest do
     expected = [@url_1, @url_2]
     assert(expected == Onigumo.load_urls(filepath))
   end
-
 end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -3,8 +3,8 @@ defmodule OnigumoTest do
   import Mox
 
   @urls [
-    "https://onigumo.local/hello.html",
-    "https://onigumo.local/bye.html"
+    "https://onigumo.org/hello.html",
+    "https://onigumo.org/bye.html"
   ]
 
   @filename "body.html"

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -78,7 +78,7 @@ defmodule OnigumoTest do
     url = Enum.at(@urls, 0)
 
     filepath = Path.join(tmp_dir, @testfile_with_urls)
-    content = "#{url}\n"
+    content = url <> "\n"
     File.write!(filepath, content)
 
     expected = [url]

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -61,7 +61,7 @@ defmodule OnigumoTest do
       end
     )
 
-    content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
+    content = Enum.map(@urls, &(&1 <> " \n")) |> Enum.join()
     File.write!(@testfile_with_urls, content)
 
     last_url = Enum.at(@urls, -1)
@@ -86,7 +86,7 @@ defmodule OnigumoTest do
   @tag :tmp_dir
   test("load multiple URLs from a file", %{tmp_dir: tmp_dir}) do
     filepath = Path.join(tmp_dir, @testfile_with_urls)
-    content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
+    content = Enum.map(@urls, &(&1 <> " \n")) |> Enum.join()
     File.write!(filepath, content)
 
     assert(@urls == Onigumo.load_urls(filepath))

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -66,8 +66,6 @@ defmodule OnigumoTest do
 
     last_url = Enum.at(@urls, -1)
     expected = "Body from: #{last_url}"
-    # load urls from urls_file
-    # read result from some test file
     Onigumo.download(HTTPoisonMock)
 
     assert(expected == File.read!(@filename))

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -4,8 +4,6 @@ defmodule OnigumoTest do
 
   @url_1 "http://onigumo.org/hello.html"
   @url_2 "http://onigumo.org/bye.html"
-  @filename "body.html"
-  @testfile_with_urls "urls.txt"
 
   setup(:verify_on_exit!)
 
@@ -57,7 +55,7 @@ defmodule OnigumoTest do
 
   @tag :tmp_dir
   test("load one URL from file", %{tmp_dir: tmp_dir}) do
-    filepath = Path.join(tmp_dir, @testfile_with_urls)
+    filepath = Path.join(tmp_dir, "input_file")
     content = "#{@url_1}\n"
     File.write!(filepath, content)
 
@@ -67,7 +65,7 @@ defmodule OnigumoTest do
 
   @tag :tmp_dir
   test("load two URLs from file", %{tmp_dir: tmp_dir}) do
-    filepath = Path.join(tmp_dir, @testfile_with_urls)
+    filepath = Path.join(tmp_dir, "input_file")
     content = "#{@url_1}\n#{@url_2}\n"
     File.write!(filepath, content)
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -63,7 +63,7 @@ defmodule OnigumoTest do
     expected = "Body from: #{@url_2}\n"
     # load urls from urls_file
     # read result from some test file
-    Onigumo.save_urls_contents(HTTPoisonMock)
+    Onigumo.download(HTTPoisonMock)
 
     assert(expected == File.read!(@output_filename))
   end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -2,13 +2,14 @@ defmodule OnigumoTest do
   use ExUnit.Case
   import Mox
 
-  @url "http://onigumo.org/hello.html"
+  @url_1 "http://onigumo.org/hello.html"
+  @url_2 "http://onigumo.org/bye.html"
   @filename "body.html"
   @testfile_with_urls "urls.txt"
 
   setup(:verify_on_exit!)
 
-  test("download") do
+  test("download one URL") do
     expect(
       HTTPoisonMock,
       :get!,
@@ -20,18 +21,50 @@ defmodule OnigumoTest do
       end
     )
 
-    assert(:ok == Onigumo.download(HTTPoisonMock, @url))
-    assert("Body from: #{@url}" == File.read!(@filename))
+    assert(:ok == Onigumo.download(HTTPoisonMock, @url_1))
+    assert("Body from: #{@url_1}" == File.read!(@filename))
+  end
+
+  @tag :tmp_dir
+  test("download multiply URLs", %{tmp_dir: tmp_dir}) do
+    expect(
+      HTTPoisonMock,
+      :get!,
+      fn url ->
+        %HTTPoison.Response{
+          status_code: 200,
+          body: "Body from: #{url}"
+        }
+      end
+    )
+    filepath = Path.join(tmp_dir, @testfile_with_urls)
+    content = "#{@url_1}\n#{@url_2}\n"
+    File.write!(filepath, content)
+    expected = "Body from: #{@url_1}\nBody from: #{@url_2}\n"
+    Onigumo.main(filepath)
+
+    assert(expected == File.read!(Onigumo.@output_filename))
   end
 
 
   @tag :tmp_dir
-  test("load URL from file", %{tmp_dir: tmp_dir}) do
+  test("load one URL from file", %{tmp_dir: tmp_dir}) do
     filepath = Path.join(tmp_dir, @testfile_with_urls)
-    content = @url <> " \n"
+    content = "#{@url_1}\n"
     File.write!(filepath, content)
 
-    expected = [@url]
+    expected = [@url_1]
+    assert(expected == Onigumo.load_urls(filepath))
+  end
+
+
+  @tag :tmp_dir
+  test("load two URLs from file", %{tmp_dir: tmp_dir}) do
+    filepath = Path.join(tmp_dir, @testfile_with_urls)
+    content = "#{@url_1}\n#{@url_2}\n"
+    File.write!(filepath, content)
+
+    expected = [@url_1, @url_2]
     assert(expected == Onigumo.load_urls(filepath))
   end
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -5,8 +5,8 @@ defmodule OnigumoTest do
   @url_1 "https://onigumo.local/hello.html"
   @url_2 "https://onigumo.local/bye.html"
 
-  @input_filename "urls.txt"
-  @output_filename "body.html"
+  @filename "body.html"
+  @testfile_with_urls "urls.txt"
 
   setup(:verify_on_exit!)
 
@@ -23,7 +23,7 @@ defmodule OnigumoTest do
     )
 
     assert(:ok == Onigumo.download(HTTPoisonMock, @url_1))
-    assert("Body from: #{@url_1}\n" == File.read!(@output_filename))
+    assert("Body from: #{@url_1}\n" == File.read!(@filename))
   end
 
 
@@ -42,7 +42,7 @@ defmodule OnigumoTest do
 
     urls = [@url_1, @url_2]
     assert([:ok, :ok] == Onigumo.download(HTTPoisonMock, urls))
-    assert("Body from: #{@url_2}\n" == File.read!(@output_filename))
+    assert("Body from: #{@url_2}\n" == File.read!(@filename))
   end
 
   test("download URLs from the input file") do
@@ -59,18 +59,18 @@ defmodule OnigumoTest do
     )
 
     content = "#{@url_1}\n#{@url_2}\n"
-    File.write!(@input_filename, content)
+    File.write!(@testfile_with_urls, content)
     expected = "Body from: #{@url_2}\n"
     # load urls from urls_file
     # read result from some test file
     Onigumo.download(HTTPoisonMock)
 
-    assert(expected == File.read!(@output_filename))
+    assert(expected == File.read!(@filename))
   end
 
   @tag :tmp_dir
   test("load a single URL from a file", %{tmp_dir: tmp_dir}) do
-    filepath = Path.join(tmp_dir, @input_filename)
+    filepath = Path.join(tmp_dir, @testfile_with_urls)
     content = "#{@url_1}\n"
     File.write!(filepath, content)
 
@@ -80,7 +80,7 @@ defmodule OnigumoTest do
 
   @tag :tmp_dir
   test("load multiple URLs from a file", %{tmp_dir: tmp_dir}) do
-    filepath = Path.join(tmp_dir, @input_filename)
+    filepath = Path.join(tmp_dir, @testfile_with_urls)
     content = "#{@url_1}\n#{@url_2}\n"
     File.write!(filepath, content)
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -34,7 +34,7 @@ defmodule OnigumoTest do
     expect(
       HTTPoisonMock,
       :get!,
-      2,
+      length(@urls),
       fn url ->
         %HTTPoison.Response{
           status_code: 200,
@@ -52,7 +52,7 @@ defmodule OnigumoTest do
     expect(
       HTTPoisonMock,
       :get!,
-      2,
+      length(@urls),
       fn url ->
         %HTTPoison.Response{
           status_code: 200,

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -45,6 +45,7 @@ defmodule OnigumoTest do
 
     responses = Enum.map(@urls, fn _ -> :ok end)
     assert(responses == Onigumo.download(HTTPoisonMock, @urls))
+
     last_url = Enum.at(@urls, -1)
     assert("Body from: #{last_url}" == File.read!(@filename))
   end


### PR DESCRIPTION
fix #26 

From @Glutexo: This required a slight change in the executive code so that the `download` function can accept a list of URLs without initializing the real environment application.