### PR TITLE
Remove parentheses from import

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,3 @@
-import(Config)
+import Config
 
 config(:onigumo, :http_client, HTTPoison)


### PR DESCRIPTION
In #20 we removed parentheses for [_Kernel.SpecialForms_](https://hexdocs.pm/elixir/Kernel.SpecialForms.html) like [`import`](https://hexdocs.pm/elixir/Kernel.SpecialForms.html#import/2). One import however remained unnoticed.