### PR TITLE
Swap download/2 argument order

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -10,10 +10,10 @@ defmodule Onigumo do
     http = http_client()
 
     load_urls(@input_filename)
-    |> Enum.map(&download(http, &1))
+    |> Enum.map(&download(&1, http))
   end
 
-  def download(http_client, url) do
+  def download(url, http_client) do
     %HTTPoison.Response{
       status_code: 200,
       body: body

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -20,7 +20,7 @@ defmodule OnigumoTest do
       end
     )
 
-    assert(:ok == Onigumo.download(HTTPoisonMock, @url))
+    assert(:ok == Onigumo.download(@url, HTTPoisonMock))
     assert("Body from: #{@url}" == File.read!(@filename))
   end
 


### PR DESCRIPTION
The `http_client` argument is a configuration, `url` is an input. Keep
input values first to make it easier to use with `|>` piping.

```elixir
get_url() |> download(http_client)
```