### PR TITLE
Remove unwanted space from URL list

### DIFF
--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -28,7 +28,7 @@ defmodule OnigumoTest do
   @tag :tmp_dir
   test("load URL from file", %{tmp_dir: tmp_dir}) do
     filepath = Path.join(tmp_dir, @testfile_with_urls)
-    content = @url <> " \n"
+    content = @url <> "\n"
     File.write!(filepath, content)
 
     expected = [@url]


### PR DESCRIPTION
The "load URL from file" test contained an unwanted space in the URL list written to a file. The URLs are expected not to have any whitespace other than the newline.