### PR TITLE
Parametrize output filename

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -10,16 +10,16 @@ defmodule Onigumo do
     http = http_client()
 
     load_urls(@input_filename)
-    |> Enum.map(&download(http, &1))
+    |> Enum.map(&download(http, &1, @output_filename))
   end
 
-  def download(http_client, url) do
+  def download(http_client, url, filename) do
     %HTTPoison.Response{
       status_code: 200,
       body: body
     } = http_client.get!(url)
 
-    File.write!(@output_filename, body)
+    File.write!(filename, body)
   end
 
   def load_urls(filepath) do

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -8,7 +8,8 @@ defmodule OnigumoTest do
 
   setup(:verify_on_exit!)
 
-  test("download") do
+  @tag :tmp_dir
+  test("download", %{tmp_dir: tmp_dir}) do
     expect(
       HTTPoisonMock,
       :get!,
@@ -20,8 +21,9 @@ defmodule OnigumoTest do
       end
     )
 
-    assert(:ok == Onigumo.download(HTTPoisonMock, @url))
-    assert("Body from: #{@url}" == File.read!(@filename))
+    filepath = Path.join(tmp_dir, @filename)
+    assert(:ok == Onigumo.download(HTTPoisonMock, @url, filepath))
+    assert("Body from: #{@url}" == File.read!(filepath))
   end
 
 


### PR DESCRIPTION
This allows to use `tmp_dir` for `download/2` (now `/3`) tests.

Fixes #32 if not considering #29.