### PR TITLE
Extract URL input file composition

### DIFF
--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -63,7 +63,7 @@ defmodule OnigumoTest do
     input_urls = Enum.slice(@urls, 0, 1)
 
     path = Path.join(tmp_dir, @input_path)
-    content = urls_input(input_urls)
+    content = prepare_input(input_urls)
     File.write!(path, content)
 
     loaded_urls = Onigumo.load_urls(path)
@@ -87,7 +87,7 @@ defmodule OnigumoTest do
     }
   end
 
-  defp urls_input(urls) do
+  defp prepare_input(urls) do
     Enum.map(urls, &(&1 <> "\n"))
     |> Enum.join()
   end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -27,12 +27,17 @@ defmodule OnigumoTest do
 
   @tag :tmp_dir
   test("load URL from file", %{tmp_dir: tmp_dir}) do
+    urls = [@url]
+
     filepath = Path.join(tmp_dir, @testfile_with_urls)
-    content = @url <> " \n"
+    content = urls_input(urls)
     File.write!(filepath, content)
 
-    expected = [@url]
-    assert(expected == Onigumo.load_urls(filepath))
+    assert(urls == Onigumo.load_urls(filepath))
   end
 
+  defp urls_input(urls) do
+    Enum.map(urls, &(&1 <> " \n"))
+    |> Enum.join()
+  end
 end


### PR DESCRIPTION
DRY the URL input file composition to a new function. This is going to be useful when testing multiple URLs. Also allows to keep only one list of URLs around in the existing tests.