### PR TITLE
Move input filename to config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,6 @@
 import Config
 
+config(:onigumo, :input_filename, "urls.txt")
+
 env = config_env()
 import_config("#{env}.exs")

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -2,14 +2,14 @@ defmodule Onigumo do
   @moduledoc """
   Web scraper
   """
-  @input_filename "urls.txt"
   @output_filename "body.html"
 
   def main() do
     HTTPoison.start()
     http = http_client()
 
-    load_urls(@input_filename)
+    Application.get_env(:onigumo, :input_filename)
+    |> load_urls()
     |> Enum.map(&download(http, &1))
   end
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -4,7 +4,6 @@ defmodule OnigumoTest do
 
   @url "http://onigumo.org/hello.html"
   @filename "body.html"
-  @testfile_with_urls "urls.txt"
 
   setup(:verify_on_exit!)
 
@@ -27,7 +26,7 @@ defmodule OnigumoTest do
 
   @tag :tmp_dir
   test("load URL from file", %{tmp_dir: tmp_dir}) do
-    filepath = Path.join(tmp_dir, @testfile_with_urls)
+    filepath = Path.join(tmp_dir, "urls.txt")
     content = @url <> " \n"
     File.write!(filepath, content)
 


### PR DESCRIPTION
An input filename is a configuration value, it does not have to be a module constant. This extraction allows to use this value in tests too.

With this change, I removed the `@testfile_with_urls` attribute from the tests. Its purpose was to expose an otherwise inaccessible value in the `Onigumo` module. With `@input_file` moved to the config, this is no longer necessary, as it’s accessible with `Application.get_env(:onigumo, :input_file)`.

`load_urls/1` takes the filename as an argument and did not have to use the global value even before this change.

Fixes #31.