### PR TITLE
Remove http_client function

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -7,10 +7,10 @@ defmodule Onigumo do
 
   def main() do
     HTTPoison.start()
-    http = http_client()
+    http_client = Application.get_env(:onigumo, :http_client)
 
     load_urls(@input_filename)
-    |> Enum.map(&download(http, &1))
+    |> Enum.map(&download(http_client, &1))
   end
 
   def download(http_client, url) do
@@ -25,9 +25,5 @@ defmodule Onigumo do
   def load_urls(filepath) do
     File.stream!(filepath, [:read], :line)
     |> Enum.map(&String.trim_trailing/1)
-  end
-
-  defp http_client() do
-    Application.get_env(:onigumo, :http_client)
   end
 end


### PR DESCRIPTION
There is no need to have a separate http_client function that only simply wraps around `Application.get_env/3` called from a single place. In the tests we are mocking _HTTPoison_ by replacing the configuration (environment) value, not by replacing this function. The mocking this continues to work even without a dedicated function.

This also removes the need of having a variable of a different name that would store the HTTP client module and moves the environment initialization to the top of the `main/0` function.

This pull request invalidates https://github.com/Glutexo/onigumo/pull/38.