### PR TITLE
Test load multiple URLs

### DIFF
--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -2,7 +2,10 @@ defmodule OnigumoTest do
   use ExUnit.Case
   import Mox
 
-  @url "http://onigumo.org/hello.html"
+  @urls [
+    "http://onigumo.org/hello.html",
+    "http://onigumo.org/bye.html"
+  ]
   @filename "body.html"
   @testfile_with_urls "urls.txt"
 
@@ -20,19 +23,30 @@ defmodule OnigumoTest do
       end
     )
 
-    assert(:ok == Onigumo.download(HTTPoisonMock, @url))
-    assert("Body from: #{@url}" == File.read!(@filename))
+    url = Enum.at(@urls, 0)
+    assert(:ok == Onigumo.download(HTTPoisonMock, url))
+    assert("Body from: #{url}" == File.read!(@filename))
   end
 
 
   @tag :tmp_dir
-  test("load URL from file", %{tmp_dir: tmp_dir}) do
+  test("load a single URL form a file", %{tmp_dir: tmp_dir}) do
+    url = Enum.at(@urls, 0)
+    
     filepath = Path.join(tmp_dir, @testfile_with_urls)
-    content = @url <> " \n"
+    content = url <> " \n"
     File.write!(filepath, content)
 
-    expected = [@url]
+    expected = [url]
     assert(expected == Onigumo.load_urls(filepath))
   end
 
+  @tag :tmp_dir
+  test("load multiple URLs from a file", %{tmp_dir: tmp_dir}) do
+    filepath = Path.join(tmp_dir, @testfile_with_urls)
+    content = Enum.map(@urls, &(&1 <> " \n")) |> Enum.join()
+    File.write!(filepath, content)
+
+    assert(@urls == Onigumo.load_urls(filepath))
+  end
 end


### PR DESCRIPTION
Extracted the `load_urls/1` test for multiple URLs from #29 to make the changes more atomic. It reintroduces some necessary changes like switching from a single `@url` attribute to a multiple `@urls` list attribute. I kept the style of the existing tests, keeping possible refactoring to follow-up pull requests, most of which are already in place.