### PR TITLE
Change test URL domain to local

### DIFF
--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -2,7 +2,7 @@ defmodule OnigumoTest do
   use ExUnit.Case
   import Mox
 
-  @url "http://onigumo.org/hello.html"
+  @url "http://onigumo.local/hello.html"
   @filename "body.html"
   @testfile_with_urls "urls.txt"
 


### PR DESCRIPTION
To avoid accidentally hitting a real world server in case of failed mocking.