### PR TITLE
Index output files

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -10,16 +10,20 @@ defmodule Onigumo do
     http = http_client()
 
     load_urls(@input_filename)
-    |> Enum.map(&download(http, &1))
+    |> Enum.with_index()
+    |> Enum.map(fn {url, index} ->
+      download(http, url, index)
+    end)
   end
 
-  def download(http_client, url) do
+  def download(http_client, url, index) do
     %HTTPoison.Response{
       status_code: 200,
       body: body
     } = http_client.get!(url)
 
-    File.write!(@output_filename, body)
+    filename = "#{index}_#{@output_filename}"
+    File.write!(filename, body)
   end
 
   def load_urls(filepath) do

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -2,13 +2,12 @@ defmodule Onigumo do
   @moduledoc """
   Web scraper
   """
-  @output_path "body.html"
-
   def main() do
     http_client = Application.get_env(:onigumo, :http_client)
     http_client.start()
 
-    download(http_client, @output_path)
+    path = File.cwd!()
+    download(http_client, path)
   end
 
   def download(http_client, path) do
@@ -21,8 +20,9 @@ defmodule Onigumo do
     urls
     |> Enum.with_index()
     |> Enum.map(fn {url, index} ->
-      indexed_path = "#{index}_#{path}"
-      download(url, http_client, indexed_path)
+      file_name = Integer.to_string(index)
+      file_path = Path.join(path, file_name)
+      download(url, http_client, file_path)
     end)
   end
 

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -17,13 +17,11 @@ defmodule Onigumo do
   end
 
   def download(urls, http_client, path) when is_list(urls) do
-    urls
-    |> Enum.with_index()
-    |> Enum.map(fn {url, index} ->
+    for {url, index} <- Enum.with_index(urls) do
       file_name = Integer.to_string(index)
       file_path = Path.join(path, file_name)
       download(url, http_client, file_path)
-    end)
+    end
   end
 
   def download(url, http_client, path) when is_binary(url) do

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -20,8 +20,11 @@ defmodule OnigumoTest do
       end
     )
 
-    assert(:ok == Onigumo.download(HTTPoisonMock, @url))
-    assert("Body from: #{@url}" == File.read!(@filename))
+    index = 0
+    assert(:ok == Onigumo.download(HTTPoisonMock, @url, index))
+
+    filename = "#{index}_#{@filename}"
+    assert("Body from: #{@url}" == File.read!(filename))
   end
 
 


### PR DESCRIPTION
Prepend a numbered index to the output files. This allows to download multiple URLs without overwriting the same file.

This would make much more sense if combined with #40. Like that it would be possible to create a filename generator function that could then be nicely replaced by a solution for #11.

Just proposing the idea for now as it would help tests in #29.