### PR TITLE
Always use env HTTP client

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -6,8 +6,8 @@ defmodule Onigumo do
   @output_filename "body.html"
 
   def main() do
-    HTTPoison.start()
     http = http_client()
+    http.start()
 
     load_urls(@input_filename)
     |> Enum.map(&download(http, &1))


### PR DESCRIPTION
`Application.get_env(:onigumo, :http_client)` returns `HTTPoison` in dev environment. This value can be used to call `start` upon. Doing so the dichotomy between using literal `HTTPoison` for `start`, but the env one for `get!` would disappear.

Related to https://github.com/Glutexo/onigumo/pull/46.