### PR TITLE
Use more explicit names in tests

### DIFF
--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -14,15 +14,15 @@ defmodule OnigumoTest do
   test("download a single URL", %{tmp_dir: tmp_dir}) do
     expect(HTTPoisonMock, :get!, &get!/1)
 
-    first_url = Enum.at(@urls, 0)
+    input_url = Enum.at(@urls, 0)
     output_path = Path.join(tmp_dir, @output_path)
     download_result = Onigumo.download(
-      first_url, HTTPoisonMock, output_path
+      input_url, HTTPoisonMock, output_path
     )
     assert(download_result == :ok)
 
     read_output = File.read!(output_path)
-    expected_output = body(first_url)
+    expected_output = body(input_url)
     assert(read_output == expected_output)
   end
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -14,73 +14,77 @@ defmodule OnigumoTest do
   test("download a single URL", %{tmp_dir: tmp_dir}) do
     expect(HTTPoisonMock, :get!, &get!/1)
 
-    url = Enum.at(@urls, 0)
-    tmp_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(url, HTTPoisonMock, tmp_path)
-    assert(result == :ok)
+    first_url = Enum.at(@urls, 0)
+    output_path = Path.join(tmp_dir, @output_path)
+    download_result = Onigumo.download(
+      first_url, HTTPoisonMock, output_path
+    )
+    assert(download_result == :ok)
 
-    read_content = File.read!(tmp_path)
-    expected_content = body(url)
-    assert(read_content == expected_content)
+    read_output = File.read!(output_path)
+    expected_output = body(first_url)
+    assert(read_output == expected_output)
   end
 
   @tag :tmp_dir
   test("download multiple URLs", %{tmp_dir: tmp_dir}) do
     expect(HTTPoisonMock, :get!, length(@urls), &get!/1)
 
-    tmp_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(@urls, HTTPoisonMock, tmp_path)
-    responses = Enum.map(@urls, fn _ -> :ok end)
-    assert(result == responses)
+    output_path = Path.join(tmp_dir, @output_path)
+    download_result = Onigumo.download(
+      @urls, HTTPoisonMock, output_path
+    )
+    expected_responses = Enum.map(@urls, fn _ -> :ok end)
+    assert(download_result == expected_responses)
 
-    read_content = File.read!(tmp_path)
+    read_output = File.read!(output_path)
     last_url = Enum.at(@urls, -1)
-    expected_content = body(last_url)
-    assert(read_content == expected_content)
+    expected_output = body(last_url)
+    assert(read_output == expected_output)
   end
 
   @tag :tmp_dir
   test("download URLs from the input file", %{tmp_dir: tmp_dir}) do
     expect(HTTPoisonMock, :get!, length(@urls), &get!/1)
 
-    env_path = Application.get_env(:onigumo, :input_path)
-    input_path = Path.join(tmp_dir, env_path)
-    content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
-    File.write!(input_path, content)
+    input_path_env = Application.get_env(:onigumo, :input_path)
+    input_path_tmp = Path.join(tmp_dir, input_path_env)
+    input_file_content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
+    File.write!(input_path_tmp, input_file_content)
 
     output_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(@urls, HTTPoisonMock, output_path)
-    responses = Enum.map(@urls, fn _ -> :ok end)
-    assert(result == responses)
+    download_result = Onigumo.download(@urls, HTTPoisonMock, output_path)
+    expected_responses = Enum.map(@urls, fn _ -> :ok end)
+    assert(download_result == expected_responses)
 
     last_url = Enum.at(@urls, -1)
-    read_content = File.read!(output_path)
-    expected_content = body(last_url)
-    assert(read_content == expected_content)
+    read_output = File.read!(output_path)
+    expected_output = body(last_url)
+    assert(read_output == expected_output)
   end
 
   @tag :tmp_dir
   test("load a single URL from a file", %{tmp_dir: tmp_dir}) do
     input_urls = Enum.slice(@urls, 0, 1)
 
-    env_path = Application.get_env(:onigumo, :input_path)
-    tmp_path = Path.join(tmp_dir, env_path)
-    content = prepare_input(input_urls)
-    File.write!(tmp_path, content)
+    input_path_env = Application.get_env(:onigumo, :input_path)
+    input_path_tmp = Path.join(tmp_dir, input_path_env)
+    input_file_content = prepare_input(input_urls)
+    File.write!(input_path_tmp, input_file_content)
 
-    loaded_urls = Onigumo.load_urls(tmp_path)
+    loaded_urls = Onigumo.load_urls(input_path_tmp)
     assert(loaded_urls == input_urls)
   end
 
   @tag :tmp_dir
   test("load multiple URLs from a file", %{tmp_dir: tmp_dir}) do
-    env_path = Application.get_env(:onigumo, :input_path)
-    tmp_path = Path.join(tmp_dir, env_path)
-    content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
-    File.write!(tmp_path, content)
+    input_path_env = Application.get_env(:onigumo, :input_path)
+    input_path_tmp = Path.join(tmp_dir, input_path_env)
+    input_file_content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
+    File.write!(input_path_tmp, input_file_content)
 
-    urls = Onigumo.load_urls(tmp_path)
-    assert(urls == @urls)
+    loaded_urls = Onigumo.load_urls(input_path_tmp)
+    assert(loaded_urls == @urls)
   end
 
   defp get!(url) do


### PR DESCRIPTION
Instead of vague names like _content_ and _tmp_, used more descriptive ones. The aim is that the variable names describe well enough what their content is, yet still being concise. A follow-up to https://github.com/Glutexo/onigumo/pull/44 based on @nappex’s [review](https://github.com/Glutexo/onigumo/pull/44#issuecomment-1030820723).