### PR TITLE
Only pass a dir path to download

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -11,9 +11,7 @@ defmodule Onigumo do
     download(http_client)
   end
 
-  def download(http_client, dir_path \\ nil)
-
-  def download(http_client, nil) do
+  def download(http_client) do
     dir_path = File.cwd!()
     download(http_client, dir_path)
   end

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -2,32 +2,40 @@ defmodule Onigumo do
   @moduledoc """
   Web scraper
   """
-  @output_path "body.html"
+  @output_file_name "body.html"
 
   def main() do
     http_client = Application.get_env(:onigumo, :http_client)
     http_client.start()
 
-    download(http_client, @output_path)
+    download(http_client)
   end
 
-  def download(http_client, path) do
+  def download(http_client, dir_path \\ nil)
+
+  def download(http_client, nil) do
+    dir_path = File.cwd!()
+    download(http_client, dir_path)
+  end
+
+  def download(http_client, dir_path) do
     Application.get_env(:onigumo, :input_path)
     |> load_urls()
-    |> download(http_client, path)
+    |> download(http_client, dir_path)
   end
 
-  def download(urls, http_client, path) when is_list(urls) do
-    Enum.map(urls, &download(&1, http_client, path))
+  def download(urls, http_client, dir_path) when is_list(urls) do
+    file_path = Path.join(dir_path, @output_file_name)
+    Enum.map(urls, &download(&1, http_client, file_path))
   end
 
-  def download(url, http_client, path) when is_binary(url) do
+  def download(url, http_client, file_path) when is_binary(url) do
     %HTTPoison.Response{
       status_code: 200,
       body: body
     } = http_client.get!(url)
 
-    File.write!(path, body)
+    File.write!(file_path, body)
   end
 
   def load_urls(path) do

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -8,10 +8,6 @@ defmodule Onigumo do
     http_client = Application.get_env(:onigumo, :http_client)
     http_client.start()
 
-    download(http_client)
-  end
-
-  def download(http_client) do
     dir_path = File.cwd!()
     download(http_client, dir_path)
   end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -28,11 +28,11 @@ defmodule OnigumoTest do
   test("download multiple URLs", %{tmp_dir: tmp_dir}) do
     expect(HTTPoisonMock, :get!, length(@urls), &get!/1)
 
-    tmp_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(@urls, HTTPoisonMock, tmp_path)
+    result = Onigumo.download(@urls, HTTPoisonMock, tmp_dir)
     responses = Enum.map(@urls, fn _ -> :ok end)
     assert(result == responses)
 
+    tmp_path = Path.join(tmp_dir, @output_path)
     read_content = File.read!(tmp_path)
     last_url = Enum.at(@urls, -1)
     expected_content = body(last_url)
@@ -49,7 +49,7 @@ defmodule OnigumoTest do
     File.write!(input_path, content)
 
     output_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(@urls, HTTPoisonMock, output_path)
+    result = Onigumo.download(@urls, HTTPoisonMock, tmp_dir)
     responses = Enum.map(@urls, fn _ -> :ok end)
     assert(result == responses)
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -50,13 +50,13 @@ defmodule OnigumoTest do
     input_file_content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
     File.write!(input_path_tmp, input_file_content)
 
-    output_path = Path.join(tmp_dir, @output_path)
     download_result = Onigumo.download(@urls, HTTPoisonMock, tmp_dir)
     expected_responses = Enum.map(@urls, fn _ -> :ok end)
     assert(download_result == expected_responses)
 
-    last_url = Enum.at(@urls, -1)
+    output_path = Path.join(tmp_dir, @output_path)
     read_output = File.read!(output_path)
+    last_url = Enum.at(@urls, -1)
     expected_output = body(last_url)
     assert(read_output == expected_output)
   end


### PR DESCRIPTION
Using a static file path as an argument to the function that download more than one URL makes it impossible to generate the file names dynamically. Only kept the file path argument for the final `download/3` function accepting only one URL. Turned the argument of all other functions to a directory path, defaulting to the current working directory.

The new `download/1` function is untested, because there is no way to test it without custom behaviors or the `File` module mocking.