### PR TITLE
Use default argument for load_urls

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -12,8 +12,7 @@ defmodule Onigumo do
   end
 
   def download(http_client, path) do
-    Application.get_env(:onigumo, :input_path)
-    |> load_urls()
+    load_urls()
     |> download(http_client, path)
   end
 
@@ -28,6 +27,13 @@ defmodule Onigumo do
     } = http_client.get!(url)
 
     File.write!(path, body)
+  end
+
+  def load_urls(path \\ nil)
+
+  def load_urls(nil) do
+    Application.get_env(:onigumo, :input_path)
+    |> load_urls()
   end
 
   def load_urls(path) do


### PR DESCRIPTION
Keep the logic of load_urls input in this function. Leverage default argument values to achieve this. As a result, the `download/2` function is simplified.