### PR TITLE
Convert load_urls to a Stream

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -15,6 +15,11 @@ defmodule Onigumo do
     Application.get_env(:onigumo, :input_path)
     |> load_urls()
     |> download(http_client, path)
+    |> Stream.run()
+  end
+
+  def download(urls = %Stream{}, http_client, path) do
+    Stream.map(urls, &download(&1, http_client, path))
   end
 
   def download(urls, http_client, path) when is_list(urls) do
@@ -32,6 +37,6 @@ defmodule Onigumo do
 
   def load_urls(path) do
     File.stream!(path, [:read], :line)
-    |> Enum.map(&String.trim_trailing/1)
+    |> Stream.map(&String.trim_trailing/1)
   end
 end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -68,7 +68,7 @@ defmodule OnigumoTest do
     content = prepare_input(input_urls)
     File.write!(tmp_path, content)
 
-    loaded_urls = Onigumo.load_urls(tmp_path)
+    loaded_urls = Onigumo.load_urls(tmp_path) |> Enum.to_list()
     assert(loaded_urls == input_urls)
   end
 
@@ -79,7 +79,7 @@ defmodule OnigumoTest do
     content = prepare_input(@urls)
     File.write!(tmp_path, content)
 
-    urls = Onigumo.load_urls(tmp_path)
+    urls = Onigumo.load_urls(tmp_path) |> Enum.to_list()
     assert(urls == @urls)
   end
 


### PR DESCRIPTION
The downloading should work as a stream, everything from picking the URL from the file through the download from the Internet to the local drive file write should happen separately for every item, not by repeated enumeration over a list. ~~This required another version of the `download/3` function accepting a `Stream` and returning a `Stream`.~~ Started with converting the `load_urls/1` function to a `Stream`.