### PR TITLE
Remove download_urls/3

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -8,17 +8,16 @@ defmodule Onigumo do
     http_client = Application.get_env(:onigumo, :http_client)
     http_client.start()
 
+    download(http_client, @output_path)
+  end
+
+  def download(http_client, path) do
     Application.get_env(:onigumo, :input_path)
-    |> download_urls(http_client, @output_path)
-  end
-
-  def download_urls(input_path, http_client, output_path) do
-    input_path
     |> load_urls()
-    |> Enum.map(&download_url(&1, http_client, output_path))
+    |> Enum.map(&download(&1, http_client, path))
   end
 
-  def download_url(url, http_client, path) do
+  def download(url, http_client, path) do
     %HTTPoison.Response{
       status_code: 200,
       body: body

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -8,20 +8,17 @@ defmodule Onigumo do
     http_client = Application.get_env(:onigumo, :http_client)
     http_client.start()
 
-    download(http_client, @output_path)
-  end
-
-  def download(http_client, path) do
     Application.get_env(:onigumo, :input_path)
+    |> download_urls(http_client, @output_path)
+  end
+
+  def download_urls(input_path, http_client, output_path) do
+    input_path
     |> load_urls()
-    |> download(http_client, path)
+    |> Enum.map(&download_url(&1, http_client, output_path))
   end
 
-  def download(urls, http_client, path) when is_list(urls) do
-    Enum.map(urls, &download(&1, http_client, path))
-  end
-
-  def download(url, http_client, path) when is_binary(url) do
+  def download_url(url, http_client, path) do
     %HTTPoison.Response{
       status_code: 200,
       body: body

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -11,31 +11,16 @@ defmodule OnigumoTest do
   setup(:verify_on_exit!)
 
   @tag :tmp_dir
-  test("download a single URL", %{tmp_dir: tmp_dir}) do
+  test("download a URL", %{tmp_dir: tmp_dir}) do
     expect(HTTPoisonMock, :get!, &get!/1)
 
     url = Enum.at(@urls, 0)
     tmp_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(url, HTTPoisonMock, tmp_path)
+    result = Onigumo.download_url(url, HTTPoisonMock, tmp_path)
     assert(result == :ok)
 
     read_content = File.read!(tmp_path)
     expected_content = body(url)
-    assert(read_content == expected_content)
-  end
-
-  @tag :tmp_dir
-  test("download multiple URLs", %{tmp_dir: tmp_dir}) do
-    expect(HTTPoisonMock, :get!, length(@urls), &get!/1)
-
-    tmp_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(@urls, HTTPoisonMock, tmp_path)
-    responses = Enum.map(@urls, fn _ -> :ok end)
-    assert(result == responses)
-
-    read_content = File.read!(tmp_path)
-    last_url = Enum.at(@urls, -1)
-    expected_content = body(last_url)
     assert(read_content == expected_content)
   end
 
@@ -49,7 +34,7 @@ defmodule OnigumoTest do
     File.write!(input_path, content)
 
     output_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(@urls, HTTPoisonMock, output_path)
+    result = Onigumo.download_urls(input_path, HTTPoisonMock, output_path)
     responses = Enum.map(@urls, fn _ -> :ok end)
     assert(result == responses)
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -16,7 +16,7 @@ defmodule OnigumoTest do
 
     url = Enum.at(@urls, 0)
     tmp_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download_url(url, HTTPoisonMock, tmp_path)
+    result = Onigumo.download(url, HTTPoisonMock, tmp_path)
     assert(result == :ok)
 
     read_content = File.read!(tmp_path)
@@ -34,9 +34,10 @@ defmodule OnigumoTest do
     File.write!(input_path, content)
 
     output_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download_urls(input_path, HTTPoisonMock, output_path)
-    responses = Enum.map(@urls, fn _ -> :ok end)
-    assert(result == responses)
+    Enum.map(@urls, fn url ->
+      result = Onigumo.download(url, HTTPoisonMock, output_path)
+      assert(result == :ok)
+    end)
 
     last_url = Enum.at(@urls, -1)
     read_content = File.read!(output_path)


### PR DESCRIPTION
As mentioned in https://github.com/Glutexo/onigumo/pull/66#issuecomment-1037506389, enumerable traversal is a trivial concept. It does not make sense to have a separate function just to do `Enum.map`. It brings confusing function dichotomy and a need for guard clauses. Also it discourages from using other types of enumerables like streams.

For the function to be testable, the `get_env` call needed to be moved to `main/0`, which makes nice symmetry with `http_client`. Because the `input_path` parameter is of the same type and thus indistinguishable from a URL, it only makes sense to rename the function.