### PR TITLE
Move get input path to main

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -12,7 +12,7 @@ defmodule Onigumo do
     |> download_urls(http_client, @output_path)
   end
 
-  def download_urls(input_path, http_client, output_path) when is_bitstring(input_path) do
+  def download_urls(input_path, http_client, output_path) when is_binary(input_path) do
     input_path
     |> load_urls()
     |> download_urls(http_client, output_path)
@@ -22,7 +22,7 @@ defmodule Onigumo do
     Enum.map(urls, &download_url(&1, http_client, path))
   end
 
-  def download_url(url, http_client, path) when is_binary(url) do
+  def download_url(url, http_client, path) do
     %HTTPoison.Response{
       status_code: 200,
       body: body

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -10,16 +10,16 @@ defmodule Onigumo do
 
     dir_path = File.cwd!()
     Application.get_env(:onigumo, :input_path)
-    |> download_urls(http_client, dir_path)
+    |> download_urls_from_file(http_client, dir_path)
   end
 
-  def download_urls(input_path, http_client, dir_path) when is_binary(input_path) do
+  def download_urls_from_file(input_path, http_client, dir_path) do
     input_path
     |> load_urls()
     |> download_urls(http_client, dir_path)
   end
 
-  def download_urls(urls, http_client, dir_path) when is_list(urls) do
+  def download_urls(urls, http_client, dir_path) do
     file_path = Path.join(dir_path, @output_file_name)
     Enum.map(urls, &download_url(&1, http_client, file_path))
   end

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -8,20 +8,21 @@ defmodule Onigumo do
     http_client = Application.get_env(:onigumo, :http_client)
     http_client.start()
 
-    download(http_client, @output_path)
-  end
-
-  def download(http_client, path) do
     Application.get_env(:onigumo, :input_path)
+    |> download_urls(http_client, @output_path)
+  end
+
+  def download_urls(input_path, http_client, output_path) when is_bitstring(input_path) do
+    input_path
     |> load_urls()
-    |> download(http_client, path)
+    |> download_urls(http_client, output_path)
   end
 
-  def download(urls, http_client, path) when is_list(urls) do
-    Enum.map(urls, &download(&1, http_client, path))
+  def download_urls(urls, http_client, path) when is_list(urls) do
+    Enum.map(urls, &download_url(&1, http_client, path))
   end
 
-  def download(url, http_client, path) when is_binary(url) do
+  def download_url(url, http_client, path) when is_binary(url) do
     %HTTPoison.Response{
       status_code: 200,
       body: body

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -50,7 +50,7 @@ defmodule OnigumoTest do
     input_file_content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
     File.write!(input_path_tmp, input_file_content)
 
-    download_result = Onigumo.download_urls(
+    download_result = Onigumo.download_urls_from_file(
       input_path_tmp, HTTPoisonMock, tmp_dir
     )
     expected_responses = Enum.map(@urls, fn _ -> :ok end)

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -16,7 +16,7 @@ defmodule OnigumoTest do
 
     url = Enum.at(@urls, 0)
     tmp_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(url, HTTPoisonMock, tmp_path)
+    result = Onigumo.download_url(url, HTTPoisonMock, tmp_path)
     assert(result == :ok)
 
     read_content = File.read!(tmp_path)
@@ -29,7 +29,7 @@ defmodule OnigumoTest do
     expect(HTTPoisonMock, :get!, length(@urls), &get!/1)
 
     tmp_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(@urls, HTTPoisonMock, tmp_path)
+    result = Onigumo.download_urls(@urls, HTTPoisonMock, tmp_path)
     responses = Enum.map(@urls, fn _ -> :ok end)
     assert(result == responses)
 
@@ -49,7 +49,7 @@ defmodule OnigumoTest do
     File.write!(input_path, content)
 
     output_path = Path.join(tmp_dir, @output_path)
-    result = Onigumo.download(@urls, HTTPoisonMock, output_path)
+    result = Onigumo.download_urls(input_path, HTTPoisonMock, output_path)
     responses = Enum.map(@urls, fn _ -> :ok end)
     assert(result == responses)
 


### PR DESCRIPTION
It is not possible to pass a custom input file to the download function and thus the function is not testable. The existing test in fact does not test the file read at all. Fixed by moving the `get_env` call to the main method, which makes a nice symmetry with `http_client`.

Now, the test really tests what it should, the configuration loads are collected to a single place and the functions are even more atomic.

The input path is a string just as a URL and thus these two are indistinguishable. Renamed the function to `download_urls` and `download_url` to avoid this. Still using the ugly guards to distinguish between the URL list and an input file path. Addressing that would be over the scope of this changeset.

Extracted from #67 to make the changeset as small as possible.