### PR TITLE
Convert download_urls_from_file/3 to a Stream

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -11,6 +11,7 @@ defmodule Onigumo do
     dir_path = File.cwd!()
     Application.get_env(:onigumo, :input_path)
     |> download_urls_from_file(http_client, dir_path)
+    |> Stream.run()
   end
 
   def download_urls_from_file(input_path, http_client, dir_path) do
@@ -21,7 +22,7 @@ defmodule Onigumo do
 
   def download_urls(urls, http_client, dir_path) do
     file_path = Path.join(dir_path, @output_file_name)
-    Enum.map(urls, &download_url(&1, http_client, file_path))
+    Stream.map(urls, &download_url(&1, http_client, file_path))
   end
 
   def download_url(url, http_client, file_path) do

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -30,9 +30,8 @@ defmodule OnigumoTest do
   test("download multiple URLs", %{tmp_dir: tmp_dir}) do
     expect(HTTPoisonMock, :get!, length(@urls), &get!/1)
 
-    download_result = Onigumo.download_urls(@urls, HTTPoisonMock, tmp_dir)
-    expected_responses = Enum.map(@urls, fn _ -> :ok end)
-    assert(download_result == expected_responses)
+    Onigumo.download_urls(@urls, HTTPoisonMock, tmp_dir)
+    |> Stream.run()
 
     output_path = Path.join(tmp_dir, @output_path)
     read_output = File.read!(output_path)
@@ -50,11 +49,9 @@ defmodule OnigumoTest do
     input_file_content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
     File.write!(input_path_tmp, input_file_content)
 
-    download_result = Onigumo.download_urls_from_file(
+    Onigumo.download_urls_from_file(
       input_path_tmp, HTTPoisonMock, tmp_dir
-    )
-    expected_responses = Enum.map(@urls, fn _ -> :ok end)
-    assert(download_result == expected_responses)
+    ) |> Stream.run()
 
     output_path = Path.join(tmp_dir, @output_path)
     read_output = File.read!(output_path)


### PR DESCRIPTION
A Stream allows to process the URL list without collecting responses to a new in-memory list. Removed thus checking for those responses in tests. They are redundant, because `File.write!/3` always returns `:ok`. On failure, it raises an exception.

Complement to #66.