### PR TITLE
Split download_url to get and write

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -21,9 +21,13 @@ defmodule Onigumo do
 
   def download_urls(urls, http_client, dir_path) do
     file_path = Path.join(dir_path, @output_file_name)
-    urls
-    |> Enum.map(&get_url(&1, http_client))
-    |> Enum.map(&save_response(&1, file_path))
+    Enum.map(urls, &download_url(&1, http_client, file_path))
+  end
+
+  def download_url(url, http_client, file_path) do
+    url
+    |> get_url(http_client)
+    |> save_response(file_path)
   end
 
   def get_url(url, http_client) do

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -21,16 +21,21 @@ defmodule Onigumo do
 
   def download_urls(urls, http_client, dir_path) do
     file_path = Path.join(dir_path, @output_file_name)
-    Enum.map(urls, &download_url(&1, http_client, file_path))
+    urls
+    |> Enum.map(&get_url(&1, http_client))
+    |> Enum.map(&save_response(&1, file_path))
   end
 
-  def download_url(url, http_client, file_path) do
+  def get_url(url, http_client) do
     %HTTPoison.Response{
       status_code: 200,
       body: body
     } = http_client.get!(url)
+    body
+  end
 
-    File.write!(file_path, body)
+  def save_response(response, file_path) do
+    File.write!(file_path, response)
   end
 
   def load_urls(path) do

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -24,18 +24,24 @@ defmodule Onigumo do
   def download_url(url, http_client, file_path) do
     url
     |> get_url(http_client)
-    |> save_response(file_path)
+    |> get_body()
+    |> write_response(file_path)    
   end
 
   def get_url(url, http_client) do
+    http_client.get!(url)
+  end
+
+  def get_body(
     %HTTPoison.Response{
       status_code: 200,
       body: body
-    } = http_client.get!(url)
+    }
+  ) do
     body
   end
 
-  def save_response(response, file_path) do
+  def write_response(response, file_path) do
     File.write!(file_path, response)
   end
 

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -70,6 +70,33 @@ defmodule OnigumoTest do
     assert(loaded_urls == @urls)
   end
 
+  test("get response by HTTP request") do
+    expect(HTTPoisonMock, :get!, &get!/1)
+
+    url = Enum.at(@urls, 0)
+    get_response = Onigumo.get_url(url, HTTPoisonMock)
+    expected_response = get!(url)
+    assert(get_response == expected_response)
+  end
+
+  test("extract body from URL response") do
+    url = Enum.at(@urls, 0)
+    response = get!(url)
+    get_body = Onigumo.get_body(response)
+    expected_body = body(url)
+    assert(get_body == expected_body)
+  end
+
+  @tag :tmp_dir
+  test("write response to file", %{tmp_dir: tmp_dir}) do
+    response = "Response!"
+    output_path = Path.join(tmp_dir, @output_path)
+    Onigumo.write_response(response, output_path)
+
+    read_output = File.read!(output_path)
+    assert(read_output == response)
+  end
+
   defp get!(url) do
     %HTTPoison.Response{
       status_code: 200,

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -14,16 +14,14 @@ defmodule OnigumoTest do
   test("download a single URL", %{tmp_dir: tmp_dir}) do
     expect(HTTPoisonMock, :get!, &get!/1)
 
-    input_urls = Enum.slice(@urls, 0, 1)
-    download_result = Onigumo.download_urls(
-      input_urls, HTTPoisonMock, tmp_dir
-    )
-    expected_responses = Enum.map(input_urls, fn _ -> :ok end)
-    assert(download_result == expected_responses)
-
+    input_url = Enum.at(@urls, 0)
     output_path = Path.join(tmp_dir, @output_path)
+    download_result = Onigumo.download_url(
+      input_url, HTTPoisonMock, output_path
+    )
+    assert(download_result == :ok)
+
     read_output = File.read!(output_path)
-    input_url = Enum.at(input_urls, 0)
     expected_output = body(input_url)
     assert(read_output == expected_output)
   end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -14,14 +14,16 @@ defmodule OnigumoTest do
   test("download a single URL", %{tmp_dir: tmp_dir}) do
     expect(HTTPoisonMock, :get!, &get!/1)
 
-    input_url = Enum.at(@urls, 0)
-    output_path = Path.join(tmp_dir, @output_path)
-    download_result = Onigumo.download_url(
-      input_url, HTTPoisonMock, output_path
+    input_urls = Enum.slice(@urls, 0, 1)
+    download_result = Onigumo.download_urls(
+      input_urls, HTTPoisonMock, tmp_dir
     )
-    assert(download_result == :ok)
+    expected_responses = Enum.map(input_urls, fn _ -> :ok end)
+    assert(download_result == expected_responses)
 
+    output_path = Path.join(tmp_dir, @output_path)
     read_output = File.read!(output_path)
+    input_url = Enum.at(input_urls, 0)
     expected_output = body(input_url)
     assert(read_output == expected_output)
   end


### PR DESCRIPTION
To make the functions as atomic as possible split the `download_url/3` function to smaller chunks. Now, with `Enum.map` used, this is heavily inefficient as it composes a list of all responses in the memory. This can be however resolved by using [Streams](https://hexdocs.pm/elixir/Stream.html). See #66 and #71.

Fixes #19.