### PR TITLE
Use prepare_input

### DIFF
--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -47,7 +47,7 @@ defmodule OnigumoTest do
 
     input_path_env = Application.get_env(:onigumo, :input_path)
     input_path_tmp = Path.join(tmp_dir, input_path_env)
-    input_file_content = Enum.map(@urls, &(&1 <> "\n")) |> Enum.join()
+    input_file_content = prepare_input(@urls)
     File.write!(input_path_tmp, input_file_content)
 
     download_result = Onigumo.download_urls_from_file(


### PR DESCRIPTION
One tests was still manually composing the URL input file without using the extracted function.