### PR TITLE
♻️ Move HTTP client to a function

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -5,31 +5,30 @@ defmodule Onigumo do
   @output_file_name "body.html"
 
   def main() do
-    http_client = Application.get_env(:onigumo, :http_client)
-    http_client.start()
+    http_client().start()
 
     dir_path = File.cwd!()
     Application.get_env(:onigumo, :input_path)
-    |> download_urls_from_file(http_client, dir_path)
+    |> download_urls_from_file(dir_path)
     |> Stream.run()
   end
 
-  def download_urls_from_file(input_path, http_client, dir_path) do
+  def download_urls_from_file(input_path, dir_path) do
     file_path = Path.join(dir_path, @output_file_name)
     input_path
     |> load_urls()
-    |> Stream.map(&download_url(&1, http_client, file_path))
+    |> Stream.map(&download_url(&1, file_path))
   end
 
-  def download_url(url, http_client, file_path) do
+  def download_url(url, file_path) do
     url
-    |> get_url(http_client)
+    |> get_url()
     |> get_body()
     |> write_response(file_path)    
   end
 
-  def get_url(url, http_client) do
-    http_client.get!(url)
+  def get_url(url) do
+    http_client().get!(url)
   end
 
   def get_body(
@@ -48,5 +47,9 @@ defmodule Onigumo do
   def load_urls(path) do
     File.stream!(path, [:read], :line)
     |> Stream.map(&String.trim_trailing/1)
+  end
+
+  defp http_client() do
+    Application.get_env(:onigumo, :http_client)
   end
 end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -16,9 +16,7 @@ defmodule OnigumoTest do
 
     input_url = Enum.at(@urls, 0)
     output_path = Path.join(tmp_dir, @output_path)
-    download_result = Onigumo.download_url(
-      input_url, HTTPoisonMock, output_path
-    )
+    download_result = Onigumo.download_url(input_url, output_path)
     assert(download_result == :ok)
 
     read_output = File.read!(output_path)
@@ -35,9 +33,8 @@ defmodule OnigumoTest do
     input_file_content = prepare_input(@urls)
     File.write!(input_path_tmp, input_file_content)
 
-    Onigumo.download_urls_from_file(
-      input_path_tmp, HTTPoisonMock, tmp_dir
-    ) |> Stream.run()
+    Onigumo.download_urls_from_file(input_path_tmp, tmp_dir)
+    |> Stream.run()
 
     output_path = Path.join(tmp_dir, @output_path)
     read_output = File.read!(output_path)
@@ -74,7 +71,7 @@ defmodule OnigumoTest do
     expect(HTTPoisonMock, :get!, &get!/1)
 
     url = Enum.at(@urls, 0)
-    get_response = Onigumo.get_url(url, HTTPoisonMock)
+    get_response = Onigumo.get_url(url)
     expected_response = get!(url)
     assert(get_response == expected_response)
   end


### PR DESCRIPTION
To not pass the HTTP client all around, reintroduced the `http_client` function that allows to grab the module only where needed. Now there are many functions that don’t even use the HTTP client and only pass it to another function.

Fixes #76.