### PR TITLE
♻️ Move get input path to load_urls

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -9,15 +9,13 @@ defmodule Onigumo do
     http_client.start()
 
     dir_path = File.cwd!()
-    Application.get_env(:onigumo, :input_path)
-    |> download_urls_from_file(http_client, dir_path)
+    download_urls_from_file(http_client, dir_path)
     |> Stream.run()
   end
 
-  def download_urls_from_file(input_path, http_client, dir_path) do
+  def download_urls_from_file(http_client, dir_path) do
     file_path = Path.join(dir_path, @output_file_name)
-    input_path
-    |> load_urls()
+    load_urls(dir_path)
     |> Stream.map(&download_url(&1, http_client, file_path))
   end
 
@@ -45,8 +43,10 @@ defmodule Onigumo do
     File.write!(file_path, response)
   end
 
-  def load_urls(path) do
-    File.stream!(path, [:read], :line)
+  def load_urls(dir_path) do
+    input_path = Application.get_env(:onigumo, :input_path)
+    Path.join(dir_path, input_path)
+    |> File.stream!([:read], :line)
     |> Stream.map(&String.trim_trailing/1)
   end
 end

--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -35,9 +35,8 @@ defmodule OnigumoTest do
     input_file_content = prepare_input(@urls)
     File.write!(input_path_tmp, input_file_content)
 
-    Onigumo.download_urls_from_file(
-      input_path_tmp, HTTPoisonMock, tmp_dir
-    ) |> Stream.run()
+    Onigumo.download_urls_from_file(HTTPoisonMock, tmp_dir)
+    |> Stream.run()
 
     output_path = Path.join(tmp_dir, @output_path)
     read_output = File.read!(output_path)
@@ -55,7 +54,7 @@ defmodule OnigumoTest do
     input_file_content = prepare_input(input_urls)
     File.write!(input_path_tmp, input_file_content)
 
-    loaded_urls = Onigumo.load_urls(input_path_tmp) |> Enum.to_list()
+    loaded_urls = Onigumo.load_urls(tmp_dir) |> Enum.to_list()
     assert(loaded_urls == input_urls)
   end
 
@@ -66,7 +65,7 @@ defmodule OnigumoTest do
     input_file_content = prepare_input(@urls)
     File.write!(input_path_tmp, input_file_content)
 
-    loaded_urls = Onigumo.load_urls(input_path_tmp) |> Enum.to_list()
+    loaded_urls = Onigumo.load_urls(tmp_dir) |> Enum.to_list()
     assert(loaded_urls == @urls)
   end
 


### PR DESCRIPTION
There is no practical need to have the URLs input path to be passed to the function as an argument. There is only going to be a single URL input file and the tests too can load the value from the environment.

The directory path still needs to be passed around because the executive code uses the current working directory, whilst the tests use a temporary directory.