### PR TITLE
♻️ Extract download assertion

### DIFF
--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -35,13 +35,7 @@ defmodule OnigumoTest do
 
     Onigumo.download_urls_from_file(tmp_dir) |> Stream.run()
 
-    Enum.map(@urls, fn url ->
-      file_name = Base.url_encode64(url, padding: false)
-      output_path = Path.join(tmp_dir, file_name)
-      read_output = File.read!(output_path)
-      expected_output = body(url)
-      assert(read_output == expected_output)
-    end)
+    Enum.map(@urls, &assert_downloaded(&1, tmp_dir))
   end
 
   @tag :tmp_dir
@@ -110,5 +104,13 @@ defmodule OnigumoTest do
 
   defp body(url) do
     "Body from: #{url}\n"
+  end
+
+  defp assert_downloaded(url, tmp_dir) do
+    file_name = Base.url_encode64(url, padding: false)
+    output_path = Path.join(tmp_dir, file_name)
+    read_output = File.read!(output_path)
+    expected_output = body(url)
+    assert(read_output == expected_output)
   end
 end


### PR DESCRIPTION
To have the download test shorter and not to use an overly long anonymous function, extracted the faily complex verification of the downloaded URL to a function. This function can be easily put into `Enum.map`.

Extracted from #73.