### PR TITLE
♻️ Shorten “URL address“ to just “address”

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,24 @@ flowchart LR
 
 ### Operator ###
 
-Určuje URL adresy ke stažení pro _downloader_. Za přidávání URL adres ke zpracování je zodpovědný pavouk. Nové URL adresy pavouk získává z naparsované podoby dat, kterou vytváří _parser_.
+Určuje adresy ke stažení pro _downloader_. Za přidávání adres ke zpracování je zodpovědný pavouk. Nové adresy pavouk získává z naparsované podoby dat, kterou vytváří _parser_.
 
 Činnost _operatoru_ se skládá z:
 
 1. inicializace pavouka,
-2. kontroly existence seznamu nových URL adres,
-3. načítání nových URL adres ze strukturovaných dat,
-4. zařazování těchto URL adres do fronty pro _downloader_.
+2. kontroly existence seznamu nových adres,
+3. načítání nových adres ze strukturovaných dat,
+4. zařazování těchto adres do fronty pro _downloader_.
 
 ### Downloader ###
 
-Stahuje obsah a metadata nezpracovaných URL adres.
+Stahuje obsah a metadata nezpracovaných adres.
 
 Činnost _downloaderu_ se skládá z:
 
-1. načítání URL adres ke stažení,
+1. načítání adres ke stažení,
 2. kontroly již existujících stažených,
-3. stahování obsahu URL adres a případných metadat,
+3. stahování obsahu adres a případných metadat,
 4. uložení stažených dat.
 
 ### Parser ###
@@ -53,8 +53,8 @@ Zpracovává data ze staženého obsahu a metadat do strukturované podoby.
 
 Činnost _parseru_ se skládá z:
 
-1. kontroly stažených URL adres ke zpracování,
-2. zpracovávání obsahu a metadat stažených URL adres do strukturované podoby dat,
+1. kontroly stažených adres ke zpracování,
+2. zpracovávání obsahu a metadat stažených adres do strukturované podoby dat,
 3. ukládání strukturovaných dat.
 
 ## Aplikace (pavouci) ##

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Určuje URL adresy ke stažení pro _downloader_. Za přidávání URL ke zpraco
 Činnost _operatoru_ se skládá z:
 
 1. inicializace pavouka,
-2. kontroly existence seznamu nových URB,
+2. kontroly existence seznamu nových URL,
 3. načítání nových URL ze strukturovaných dat,
 4. zařazování těchto URL do fronty pro _downloader_.
 

--- a/README.md
+++ b/README.md
@@ -27,24 +27,24 @@ flowchart LR
 
 ### Operator ###
 
-Určuje adresy ke stažení pro _downloader_. Za přidávání adres ke zpracování je zodpovědný pavouk. Nové adresy pavouk získává z naparsované podoby dat, kterou vytváří _parser_.
+Určuje URL adresy ke stažení pro _downloader_. Za přidávání URL ke zpracování je zodpovědný pavouk. Nové URL pavouk získává z naparsované podoby dat, kterou vytváří _parser_.
 
 Činnost _operatoru_ se skládá z:
 
 1. inicializace pavouka,
-2. kontroly existence seznamu nových adres,
-3. načítání nových adres ze strukturovaných dat,
-4. zařazování těchto adres do fronty pro _downloader_.
+2. kontroly existence seznamu nových URB,
+3. načítání nových URL ze strukturovaných dat,
+4. zařazování těchto URL do fronty pro _downloader_.
 
 ### Downloader ###
 
-Stahuje obsah a metadata nezpracovaných adres.
+Stahuje obsah a metadata nezpracovaných URL adres.
 
 Činnost _downloaderu_ se skládá z:
 
-1. načítání adres ke stažení,
-2. kontroly stažených adres,
-3. stahování obsahu adres a případných metadat,
+1. načítání URL ke stažení,
+2. kontroly stažených URL,
+3. stahování obsahu URL a případných metadat,
 4. uložení stažených dat.
 
 ### Parser ###
@@ -53,8 +53,8 @@ Zpracovává data ze staženého obsahu a metadat do strukturované podoby.
 
 Činnost _parseru_ se skládá z:
 
-1. kontroly stažených adres ke zpracování,
-2. zpracovávání obsahu a metadat stažených adres do strukturované podoby,
+1. kontroly stažených URL adres ke zpracování,
+2. zpracovávání obsahu a metadat stažených URL do strukturované podoby,
 3. ukládání strukturovaných dat.
 
 ## Aplikace (pavouci) ##


### PR DESCRIPTION
I find the “URL address” expression too wordy. I picked “address,” but “URL” would be OK too. In English, I’d instead choose the “URL” version.