### PR TITLE
📝 Add links to Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Onigumo is yet another web-crawler. It “crawls” websites or webapps, storing
 
 Onigumo is composed of three sequentially interconnected components:
 
-* the Operator,
-* the Downloader,
-* the Parser.
+* [the Operator](#operator),
+* [the Downloader](#downloader),
+* [the Parser](#parser).
 
 The flowchart below illustrates the flow of data between those parts:
 


### PR DESCRIPTION
Add anchors for better navigation from the Architecture overview to the specific sections.