### PR TITLE
🏗 Move root_path to CLI

### DIFF
--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -3,11 +3,8 @@ defmodule Onigumo do
   Web scraper
   """
 
-  def main() do
+  def main(root_path) do
     http_client().start()
-
-    root_path = File.cwd!()
-
     download_urls_from_file(root_path)
     |> Stream.run()
   end

--- a/lib/onigumo.ex
+++ b/lib/onigumo.ex
@@ -5,6 +5,7 @@ defmodule Onigumo do
 
   def main(root_path) do
     http_client().start()
+
     download_urls_from_file(root_path)
     |> Stream.run()
   end

--- a/lib/onigumo_cli.ex
+++ b/lib/onigumo_cli.ex
@@ -1,5 +1,6 @@
 defmodule Onigumo.CLI do
   def main(_args) do
-    Onigumo.main()
+    root_path = File.cwd!()
+    Onigumo.main(root_path)
   end
 end


### PR DESCRIPTION
The concept of a current working directory only applies to the command-line interface. Thus the cwd call belongs to the Onigumo.CLI module, not Onigumo. Moving this outer-world dependency out of the module makes the “main” function testable.

Fixes #119. Unblocks #56.