### PR TITLE
Rename materialization to materializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ flowchart LR
     operator   -- <hash>.urls ---> downloader(DOWNLOADER)
     downloader -- <hash>.raw  ---> parser(PARSER)
     parser     -- <hash>.json ---> operator
-    operator           -->         MATERIALIZATION
+    operator           -->         MATERIALIZER
 ```
 
 ### Operator ###


### PR DESCRIPTION
Initially, I considered the materialization a virtual step separate from Onigumo and the Spider. It, however, makes sense to enable Spiders to define ways to materialize the structured data as a natural step invokable from Onigumo.

That way, the materializer becomes a part of the Spider that does not have its Onigumo counterpart. Similarly, the Downloader exists only in Onigumo, but does not touch the Spider.