### PR TITLE
🔧 Fix GitHub actions for pull requests

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,9 +2,9 @@ name: Elixir CI
 
 on:
   push:
-    branches: [ elixir ]
+    branches: [ master ]
   pull_request:
-    branches: [ elixir ]
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
The rename of the main branch from elixir to master caused our workflow to not fire for pull requests. The cause is that the _on_ configuration explicitly mentions the branch name. https://github.com/Glutexo/onigumo/blob/3d5aa5b1c460befe86c02d25598b82a3150453f0/.github/workflows/elixir.yml#L5
https://github.com/Glutexo/onigumo/blob/3d5aa5b1c460befe86c02d25598b82a3150453f0/.github/workflows/elixir.yml#L7