### PR TITLE
🚚 Rename OnigumoTest to OnigumoDownloaderTest

### DIFF
--- a/test/onigumo_test.exs
+++ b/test/onigumo_test.exs
@@ -1,4 +1,4 @@
-defmodule OnigumoTest do
+defmodule OnigumoDownloaderTest do
   use ExUnit.Case
   import Mox
 


### PR DESCRIPTION
The former _Onigumo_ module has a new name _Onigumo.Downloader_. Rename the test module so the identifiers match.