### PR TITLE
Use download functions with pattern match

### DIFF
--- a/lib/onigumo_downloader.ex
+++ b/lib/onigumo_downloader.ex
@@ -3,14 +3,14 @@ defmodule Onigumo.Downloader do
   Web scraper
   """
 
-  def download_urls_from_file(root_path) do
+  def download(root_path) do
     root_path
     |> load_urls()
-    |> Stream.map(&download_url(&1, root_path))
+    |> Stream.map(&download(&1, root_path))
     |> Stream.run()
   end
 
-  def download_url(url, root_path) do
+  def download(url, root_path) do
     file_name = create_file_name(url)
     file_path = Path.join(root_path, file_name)
 

--- a/lib/onigumo_downloader.ex
+++ b/lib/onigumo_downloader.ex
@@ -7,13 +7,13 @@ defmodule Onigumo.Downloader do
     http_client().start()
 
     download_urls_from_file(root_path)
-    |> Stream.run()
   end
 
   def download_urls_from_file(root_path) do
     root_path
     |> load_urls()
     |> Stream.map(&download_url(&1, root_path))
+    |> Stream.run()
   end
 
   def download_url(url, root_path) do

--- a/lib/onigumo_downloader.ex
+++ b/lib/onigumo_downloader.ex
@@ -4,7 +4,6 @@ defmodule Onigumo.Downloader do
   """
 
   def main(root_path) do
-    http_client().start()
 
     download_urls_from_file(root_path)
   end
@@ -27,6 +26,7 @@ defmodule Onigumo.Downloader do
   end
 
   def get_url(url) do
+    http_client().start()
     http_client().get!(url)
   end
 

--- a/lib/onigumo_downloader.ex
+++ b/lib/onigumo_downloader.ex
@@ -3,11 +3,6 @@ defmodule Onigumo.Downloader do
   Web scraper
   """
 
-  def main(root_path) do
-
-    download_urls_from_file(root_path)
-  end
-
   def download_urls_from_file(root_path) do
     root_path
     |> load_urls()


### PR DESCRIPTION

This is just **proposal** for #150 ,

There is a problem where to write line `http_client.start()`, because now it is calling with each URL which should be handled.....

Maybe the Pattern matching should be more specific... not just by number of args but also by specific types for example...