### PR TITLE
✅ Remove redundant assert

### DIFF
--- a/test/onigumo_downloader_test.exs
+++ b/test/onigumo_downloader_test.exs
@@ -31,8 +31,7 @@ defmodule OnigumoDownloaderTest do
       expect(HTTPoisonMock, :get!, &prepare_response/1)
 
       input_url = Enum.at(@urls, 0)
-      download_result = Onigumo.Downloader.download_url(input_url, tmp_dir)
-      assert(download_result == :ok)
+      Onigumo.Downloader.download_url(input_url, tmp_dir)
 
       output_file_name = Onigumo.Downloader.create_file_name(input_url)
       output_path = Path.join(tmp_dir, output_file_name)


### PR DESCRIPTION
[_Onigumo.Downloader.download_url_](https://github.com/Glutexo/onigumo/blob/5e80cf8eb6bf0a16ed0e5bc65bc838541ed20018/lib/onigumo_downloader.ex#L19) returns the return value of [_File.write!_](https://github.com/Glutexo/onigumo/blob/5e80cf8eb6bf0a16ed0e5bc65bc838541ed20018/lib/onigumo_downloader.ex#L41), which is always _:ok_. It is redundant to check for this value and only blurs what the test really verifies.