### PR TITLE
♻️ Rename download_urls_from_file

### DIFF
--- a/lib/onigumo_downloader.ex
+++ b/lib/onigumo_downloader.ex
@@ -6,11 +6,11 @@ defmodule Onigumo.Downloader do
   def main(root_path) do
     http_client().start()
 
-    download_urls_from_file(root_path)
+    create_download_stream(root_path)
     |> Stream.run()
   end
 
-  def download_urls_from_file(root_path) do
+  def create_download_stream(root_path) do
     root_path
     |> load_urls()
     |> Stream.map(&download_url(&1, root_path))

--- a/test/onigumo_downloader_test.exs
+++ b/test/onigumo_downloader_test.exs
@@ -26,7 +26,7 @@ defmodule OnigumoDownloaderTest do
     end
   end
 
-  describe("Onigumo.Downloader.download_urls_from_file/1") do
+  describe("Onigumo.Downloader.create_download_stream/1") do
     @tag :tmp_dir
     test("download URLs from the input file", %{tmp_dir: tmp_dir}) do
       expect(HTTPoisonMock, :get!, length(@urls), &prepare_response/1)
@@ -36,7 +36,7 @@ defmodule OnigumoDownloaderTest do
       input_file_content = prepare_input(@urls)
       File.write!(input_path_tmp, input_file_content)
 
-      Onigumo.Downloader.download_urls_from_file(tmp_dir) |> Stream.run()
+      Onigumo.Downloader.create_download_stream(tmp_dir) |> Stream.run()
 
       Enum.map(@urls, &assert_downloaded(&1, tmp_dir))
     end

--- a/test/onigumo_downloader_test.exs
+++ b/test/onigumo_downloader_test.exs
@@ -28,7 +28,7 @@ defmodule OnigumoDownloaderTest do
 
   describe("Onigumo.Downloader.create_download_stream/1") do
     @tag :tmp_dir
-    test("create a stream to download URLs from the input file", %{tmp_dir: tmp_dir}) do
+    test("download URLs from the input file with a created stream", %{tmp_dir: tmp_dir}) do
       expect(HTTPoisonMock, :get!, length(@urls), &prepare_response/1)
 
       input_path_env = Application.get_env(:onigumo, :input_path)

--- a/test/onigumo_downloader_test.exs
+++ b/test/onigumo_downloader_test.exs
@@ -28,7 +28,7 @@ defmodule OnigumoDownloaderTest do
 
   describe("Onigumo.Downloader.create_download_stream/1") do
     @tag :tmp_dir
-    test("download URLs from the input file", %{tmp_dir: tmp_dir}) do
+    test("create a stream to download URLs from the input file", %{tmp_dir: tmp_dir}) do
       expect(HTTPoisonMock, :get!, length(@urls), &prepare_response/1)
 
       input_path_env = Application.get_env(:onigumo, :input_path)


### PR DESCRIPTION
The function does not download anything. It only creates a stream designated for downloading URL. This gives a false sense of complementarity to the download_url. The two functions however do very different things. Hence the rename.