### PR TITLE
Use Ubuntu 20.4 instead of latest

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out the repository


### PR DESCRIPTION
Because latest Ubundu does not support Erlang ≤ 24.1, which is the latest version supported by the latest Debian.