### PR TITLE
Fix ignoring the onigumo escript file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ onigumo-*.tar
 # Temporary files, for example, from tests.
 /tmp/
 
-onigumo
+# Ignore onigumo escript file
+/onigumo


### PR DESCRIPTION
    - old definition ignore all occurency of onigumo in path
    - it is needed to explicitly speficied we want to ignore onigumo in
      root path