### PR TITLE
Use OptionParser to parse component

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -1,5 +1,6 @@
 defmodule Onigumo.CLI do
-  def main([component]) do
+  def main(argv) do
+    {[], [component]} = OptionParser.parse!(argv, strict: [])
     module = Module.safe_concat("Onigumo", component)
     root_path = File.cwd!()
     module.main(root_path)

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -32,5 +32,9 @@ defmodule OnigumoCLITest do
     test("run CLI with more than one argument") do
       assert_raise(MatchError, fn -> Onigumo.CLI.main(["Downloader", "Parser"]) end)
     end
+
+    test("run CLI with invalid switch") do
+      assert_raise(OptionParser.ParseError, fn -> Onigumo.CLI.main(["--help"]) end)
+    end
   end
 end

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -26,11 +26,11 @@ defmodule OnigumoCLITest do
     end
 
     test("run CLI with no arguments") do
-      assert_raise(FunctionClauseError, fn -> Onigumo.CLI.main([]) end)
+      assert_raise(MatchError, fn -> Onigumo.CLI.main([]) end)
     end
 
     test("run CLI with more than one argument") do
-      assert_raise(FunctionClauseError, fn -> Onigumo.CLI.main(["Downloader", "Parser"]) end)
+      assert_raise(MatchError, fn -> Onigumo.CLI.main(["Downloader", "Parser"]) end)
     end
   end
 end

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -21,7 +21,7 @@ defmodule OnigumoCLITest do
       Onigumo.CLI.main(["Downloader"])
     end
 
-    test("run CLI with unknown argument") do
+    test("run CLI with invalid argument") do
       assert_raise(ArgumentError, fn -> Onigumo.CLI.main(["Uploader"]) end)
     end
 


### PR DESCRIPTION
fix #162 
fix #188 

I'be tried to be really consistent with existing code and make really the smallest diff as possible.
That's the one of reasons why I parse the component as positional arguments.

Nice thing was appeared, the `OptionParser` is not so good in parsing the positional arguments and its main goal is parsing `switches` (resp. `options`).

IMHO it is emphased by warning which you get from elixir, when you do not pass `:switches` or `:strict`, but these are required only for `switches`.

```shell
warning: not passing the :switches or :strict option to OptionParser is deprecate
```