### PR TITLE
Use Map instead of Module.safe_concat

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -1,7 +1,11 @@
 defmodule Onigumo.CLI do
+  @components %{
+    :Downloader => Onigumo.Downloader
+  }
+
   def main(argv) do
     {[], [component]} = OptionParser.parse!(argv, strict: [])
-    module = Module.safe_concat("Onigumo", component)
+    {:ok, module} = Map.fetch(@components, String.to_atom(component))
     root_path = File.cwd!()
     module.main(root_path)
   end

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -22,7 +22,7 @@ defmodule OnigumoCLITest do
     end
 
     test("run CLI with invalid argument") do
-      assert_raise(ArgumentError, fn -> Onigumo.CLI.main(["Uploader"]) end)
+      assert_raise(MatchError, fn -> Onigumo.CLI.main(["Uploader"]) end)
     end
 
     test("run CLI with no arguments") do


### PR DESCRIPTION
The CLI argument doesn’t need to be tightly coupled to the implementation detail of components being Elixir modules. _ArgumentError_ raised by _Module.safe_concat_ was only a symptom of that. Replaced with a mapping of string arguments (component names) to Elixir modules. As a result _MatchError_ is raised when unknown component is passed, instead of a rather cryptic ArgumentError from _Module.safe_concat_.

Fixes #196.