### PR TITLE
Change component name to lowercase

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -1,6 +1,6 @@
 defmodule Onigumo.CLI do
   @components %{
-    :Downloader => Onigumo.Downloader
+    :downloader => Onigumo.Downloader
   }
 
   def main(argv) do

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -7,6 +7,11 @@ defmodule OnigumoCLITest do
     "http://onigumo.local/bye.html"
   ]
 
+  @invalid_arguments [
+    "Downloader",
+    "uploader"
+  ]
+
   describe("Onigumo.CLI.main/1") do
     @tag :tmp_dir
     test("run CLI with 'downloader' argument", %{tmp_dir: tmp_dir}) do
@@ -21,8 +26,10 @@ defmodule OnigumoCLITest do
       Onigumo.CLI.main(["downloader"])
     end
 
-    test("run CLI with invalid argument") do
-      assert_raise(MatchError, fn -> Onigumo.CLI.main(["Uploader"]) end)
+    for argument <- @invalid_arguments do
+      test("run CLI with invalid argument #{inspect(argument)}") do
+        assert_raise(MatchError, fn -> Onigumo.CLI.main([unquote(argument)]) end)
+      end
     end
 
     test("run CLI with no arguments") do

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -9,7 +9,7 @@ defmodule OnigumoCLITest do
 
   describe("Onigumo.CLI.main/1") do
     @tag :tmp_dir
-    test("run CLI with 'Downloader' argument", %{tmp_dir: tmp_dir}) do
+    test("run CLI with 'downloader' argument", %{tmp_dir: tmp_dir}) do
       expect(HTTPoisonMock, :start, fn -> nil end)
       expect(HTTPoisonMock, :get!, length(@urls), &HttpSupport.response/1)
 
@@ -18,7 +18,7 @@ defmodule OnigumoCLITest do
       input_file_content = InputSupport.url_list(@urls)
       File.write!(input_path_tmp, input_file_content)
       File.cd(tmp_dir)
-      Onigumo.CLI.main(["Downloader"])
+      Onigumo.CLI.main(["downloader"])
     end
 
     test("run CLI with invalid argument") do


### PR DESCRIPTION
Capitalized component names were only a remnant of camel-cased elixir modules. Now, with component names being separate, there is no need to follow this convention. Lower-case arguments are the easiest way to interact with an application.

Fixes #197.