### PR TITLE
Mock Onigumo.Downloader in CLI tests

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,4 @@
 import Config
 
 config(:onigumo, :http_client, HTTPoison)
+config(:onigumo, :downloader, Onigumo.Downloader)

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,4 @@
 import Config
 
 config(:onigumo, :http_client, HTTPoisonMock)
+config(:onigumo, :downloader, OnigumoDownloaderMock)

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -1,6 +1,6 @@
 defmodule Onigumo.CLI do
   @components %{
-    :downloader => Onigumo.Downloader
+    :downloader => Application.compile_env(:onigumo, :downloader)
   }
 
   def main(argv) do

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -14,21 +14,6 @@ defmodule OnigumoCLITest do
   ]
 
   describe("Onigumo.CLI.main/1") do
-    @tag :tmp_dir
-    test("run CLI with 'downloader' argument", %{tmp_dir: tmp_dir}) do
-      expect(HTTPoisonMock, :start, fn -> nil end)
-      expect(HTTPoisonMock, :get!, length(@urls), &HttpSupport.response/1)
-      expect(OnigumoDownloaderMock, :main, fn root_path -> root_path end)
-
-      input_path_env = Application.get_env(:onigumo, :input_path)
-      input_path_tmp = Path.join(tmp_dir, input_path_env)
-      input_file_content = InputSupport.url_list(@urls)
-      File.write!(input_path_tmp, input_file_content)
-      File.cd(tmp_dir)
-
-      assert Onigumo.CLI.main(["downloader"]) == tmp_dir
-    end
-
     for argument <- @invalid_arguments do
       test("run CLI with invalid argument #{inspect(argument)}") do
         assert_raise(MatchError, fn -> Onigumo.CLI.main([unquote(argument)]) end)
@@ -45,6 +30,14 @@ defmodule OnigumoCLITest do
 
     test("run CLI with invalid switch") do
       assert usage_message_printed?(fn -> Onigumo.CLI.main(["--invalid"]) end)
+    end
+
+    @tag :tmp_dir
+    test("run CLI with 'downloader' argument passing cwd", %{tmp_dir: tmp_dir}) do
+      expect(OnigumoDownloaderMock, :main, fn root_path -> root_path end)
+
+      File.cd(tmp_dir)
+      assert Onigumo.CLI.main(["downloader"]) == tmp_dir
     end
 
     defp usage_message_printed?(function) do

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -18,13 +18,15 @@ defmodule OnigumoCLITest do
     test("run CLI with 'downloader' argument", %{tmp_dir: tmp_dir}) do
       expect(HTTPoisonMock, :start, fn -> nil end)
       expect(HTTPoisonMock, :get!, length(@urls), &HttpSupport.response/1)
+      expect(OnigumoDownloaderMock, :main, fn root_path -> root_path end)
 
       input_path_env = Application.get_env(:onigumo, :input_path)
       input_path_tmp = Path.join(tmp_dir, input_path_env)
       input_file_content = InputSupport.url_list(@urls)
       File.write!(input_path_tmp, input_file_content)
       File.cd(tmp_dir)
-      Onigumo.CLI.main(["downloader"])
+
+      assert Onigumo.CLI.main(["downloader"]) == tmp_dir
     end
 
     for argument <- @invalid_arguments do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
 ExUnit.start()
 
 Mox.defmock(HTTPoisonMock, for: HTTPoison.Base)
+Mox.defmock(OnigumoDownloaderMock, for: Onigumo.Component)


### PR DESCRIPTION
[Onigumo.Component](https://github.com/Glutexo/onigumo/blob/32ec35a3585e44ba9858513209131a9638105de5/lib/onigumo/component.ex) is a behavior that can be mocked. CLI tests don’t verify behavior of concrete components. Currently, the [Downloader](https://github.com/Glutexo/onigumo/blob/32ec35a3585e44ba9858513209131a9638105de5/lib/onigumo/downloader.ex) is only run to verify the call works. Defined a mock for the Downlader so the CLI tests only verifies its call, not its behavior.

Defined the expect mock to return the passed working directory to test it’s set properly. The assert verifies the call argument.