### PR TITLE
Remove unused @urls

### DIFF
--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -3,11 +3,6 @@ defmodule OnigumoCLITest do
   import ExUnit.CaptureIO
   import Mox
 
-  @urls [
-    "http://onigumo.local/hello.html",
-    "http://onigumo.local/bye.html"
-  ]
-
   @invalid_arguments [
     "Downloader",
     "uploader"


### PR DESCRIPTION
`@urls` module variable was only needed for the actual downloader workings. Now it being mocked, the acutual URLs are irrelevant.