### PR TITLE
Update description to match diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Onigumo is yet another web-crawler. It “crawls” websites or webapps, storing
 
 ## Architecture ##
 
-Onigumo is composed of three sequentially interconnected components:
+The crawling part of Onigumo is composed of three sequentially interconnected components:
 
 * [the Operator](#operator),
 * [the Downloader](#downloader),
 * [the Parser](#parser).
 
-The flowchart below illustrates the flow of data between those parts:
+The flowcharts below illustrate the flow of data between those parts:
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
The Operator-Downloader-Parser trinity became only a part of the whole architecture. It’s no longer true that Onigumo is composed of only three components. It wasn’t entirely true before either: there was still the idea of a Materializer.

There are two flowcharts now. It’d be possible to call them a single one consisting of two parts, but clarity doesn’t harm.

Follow-up to #237.