### PR TITLE
Split cli messages to case with invalid usage and help message

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -23,8 +23,6 @@ defmodule Onigumo.CLI do
   end
 
   defp usage_message() do
-    components = Enum.join(Map.keys(@components), ", ")
-
     IO.puts("""
     onigumo: invalid usage
     Usage: onigumo [OPTION]... [COMPONENT]

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -37,4 +37,20 @@ defmodule Onigumo.CLI do
     -C, --working-dir <dir>\tChange working dir to <dir> before running
     """)
   end
+
+  defp help_message() do
+    components = Enum.join(Map.keys(@components), ", ")
+
+    IO.puts("""
+    Usage: onigumo [OPTION]... [COMPONENT]
+
+    Simple program that retrieves HTTP web content as structured data.
+
+    COMPONENT\tOnigumo component to run, available: #{components}
+
+    OPTIONS:
+    -h, --help\t\tprint this help
+    -C, --working-dir <dir>\tChange working dir to <dir> before running
+    """)
+  end
 end

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -26,15 +26,10 @@ defmodule Onigumo.CLI do
     components = Enum.join(Map.keys(@components), ", ")
 
     IO.puts("""
+    onigumo: invalid usage
     Usage: onigumo [OPTION]... [COMPONENT]
 
-    Simple program that retrieves HTTP web content as structured data.
-
-    COMPONENT\tOnigumo component to run, available: #{components}
-
-    OPTIONS:
-    -h, --help\t\tprint this help
-    -C, --working-dir <dir>\tChange working dir to <dir> before running
+    Try `onigumo --help' for more options.
     """)
   end
 

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -10,7 +10,7 @@ defmodule Onigumo.CLI do
            strict: [help: :boolean, working_dir: :string]
          ) do
       {[help: true], [], []} ->
-        usage_message()
+        help_message()
 
       {parsed_switches, [component], []} ->
         {:ok, module} = Map.fetch(@components, String.to_atom(component))

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -74,7 +74,7 @@ defmodule OnigumoCLITest do
 
     for switch <- ["-h", "--help"] do
       test("run CLI with a #{inspect(switch)} switch") do
-        assert usage_message_printed?(fn -> Onigumo.CLI.main([unquote(switch)]) end)
+        assert help_message_printed?(fn -> Onigumo.CLI.main([unquote(switch)]) end)
       end
     end
 

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -80,7 +80,12 @@ defmodule OnigumoCLITest do
 
     defp usage_message_printed?(function) do
       output = capture_io(function)
-      String.starts_with?(output, "Usage: onigumo ")
+      String.starts_with?(output, "onigumo: invalid usage")
+    end
+
+    defp help_message_printed?(function) do
+      output = capture_io(function)
+      String.starts_with?(output, "Usage: onigumo [OPTION]... [COMPONENT]")
     end
   end
 end


### PR DESCRIPTION
fix #240 

One would be help message

another perhaps usage message for invalid usage of onifumo

This PR is done above the PR #238, because it is nature continuation of it.

Before merging this to master must be ensured merge of #238 to #242