### PR TITLE
--help to rule them all

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -6,14 +6,22 @@ defmodule Onigumo.CLI do
   def main(argv) do
     case OptionParser.parse(
            argv,
-           aliases: [C: :working_dir],
-           strict: [working_dir: :string]
-         ) do
-      {parsed_switches, [component], []} ->
-        {:ok, module} = Map.fetch(@components, String.to_atom(component))
-        working_dir = Keyword.get(parsed_switches, :working_dir, File.cwd!())
-        module.main(working_dir)
-
+           aliases: [h: :help, C: :working_dir],
+           strict: [help: :boolean, working_dir: :string]
+        ) do
+      {parsed_switches, positional_arguments, []} ->
+        if Keyword.has_key?(parsed_switches, :help) do
+          usage_message()
+        else
+          case positional_arguments do
+            [component] ->
+              {:ok, module} = Map.fetch(@components, String.to_atom(component))
+              working_dir = Keyword.get(parsed_switches, :working_dir, File.cwd!())
+              module.main(working_dir)
+            _ ->
+              usage_message()
+          end
+        end
       _ ->
         usage_message()
     end


### PR DESCRIPTION
The `-h`/`--help` switch is omnipotent. It trumps all other valid switches or positional arguments.

- `onigumo --help`
- `onigumo --help downloader`
- `onigumo downloader --help`
- `onigumo --help --working-dir . downloader`
- `onigumo --working-dir . --help downloader`
- `onigumo --working-dir . downloader --help`
- `onigumo downloader --working-dir . --help`

All the commands above print the help message. This behavior is insipired by established UNIX tools like cURL and Wget.

Resolves #205.