### PR TITLE
Replace case with with

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -4,18 +4,15 @@ defmodule Onigumo.CLI do
   }
 
   def main(argv) do
-    case OptionParser.parse(
-           argv,
-           aliases: [C: :working_dir],
-           strict: [working_dir: :string]
-         ) do
-      {parsed_switches, [component], []} ->
-        {:ok, module} = Map.fetch(@components, String.to_atom(component))
-        working_dir = Keyword.get(parsed_switches, :working_dir, File.cwd!())
-        module.main(working_dir)
+    parse_result =
+      OptionParser.parse(argv, aliases: [C: :working_dir], strict: [working_dir: :string])
 
-      _ ->
-        usage_message()
+    with {parsed_switches, [component], []} <- parse_result do
+      {:ok, module} = Map.fetch(@components, String.to_atom(component))
+      working_dir = Keyword.get(parsed_switches, :working_dir, File.cwd!())
+      module.main(working_dir)
+    else
+      _ -> usage_message()
     end
   end
 

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -4,10 +4,10 @@ defmodule Onigumo.CLI do
   }
 
   def main(argv) do
-    parse_result =
+    parsed =
       OptionParser.parse(argv, aliases: [C: :working_dir], strict: [working_dir: :string])
 
-    with {parsed_switches, [component], []} <- parse_result do
+    with {parsed_switches, [component], []} <- parsed do
       {:ok, module} = Map.fetch(@components, String.to_atom(component))
       working_dir = Keyword.get(parsed_switches, :working_dir, File.cwd!())
       module.main(working_dir)


### PR DESCRIPTION
The `case` statement is too complex for situations when we want to focus on the success branch. This is the case of `OptionParser.parse`, which fails on invalid input, but requires complex parsing of correct switches and arguments.