### PR TITLE
Help message on invalid component

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -10,9 +10,12 @@ defmodule Onigumo.CLI do
            strict: [working_dir: :string]
          ) do
       {switches, [component], []} ->
-        {:ok, module} = Map.fetch(@components, String.to_atom(component))
-        working_dir = Keyword.get(switches, :working_dir, File.cwd!())
-        module.main(working_dir)
+        with {:ok, module} <- Map.fetch(@components, String.to_atom(component)) do
+          working_dir = Keyword.get(switches, :working_dir, File.cwd!())
+          module.main(working_dir)
+        else
+          :error -> usage_message()
+        end
 
       _ ->
         usage_message()

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -21,7 +21,7 @@ defmodule OnigumoCLITest do
   describe("Onigumo.CLI.main/1") do
     for argument <- @invalid_arguments do
       test("run CLI with invalid argument #{inspect(argument)}") do
-        assert_raise(MatchError, fn -> Onigumo.CLI.main([unquote(argument)]) end)
+        assert usage_message_printed?(fn -> Onigumo.CLI.main([unquote(argument)]) end)
       end
     end
 


### PR DESCRIPTION
Passing an invalid component name prints a friendly help message instead of crashing with a stack trace. This is now consistent with a situation when an invalid switch is passed.

Fixes #189.