### PR TITLE
Remove redundant call of usage message

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -4,21 +4,14 @@ defmodule Onigumo.CLI do
   }
 
   def main(argv) do
-    case OptionParser.parse(
-           argv,
-           aliases: [C: :working_dir],
-           strict: [working_dir: :string]
-         ) do
-      {switches, [component], []} ->
-        with {:ok, module} <- Map.fetch(@components, String.to_atom(component)) do
-          working_dir = Keyword.get(switches, :working_dir, File.cwd!())
-          module.main(working_dir)
-        else
-          :error -> usage_message()
-        end
+    parsed = OptionParser.parse(argv, aliases: [C: :working_dir], strict: [working_dir: :string])
 
-      _ ->
-        usage_message()
+    with {switches, [component], []} <- parsed,
+         {:ok, module} <- Map.fetch(@components, String.to_atom(component)) do
+      working_dir = Keyword.get(switches, :working_dir, File.cwd!())
+      module.main(working_dir)
+    else
+      _ -> usage_message()
     end
   end
 


### PR DESCRIPTION
DRY if it is not necessary, then dont call function more than once.