### PR TITLE
Replace with with case

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -6,14 +6,22 @@ defmodule Onigumo.CLI do
   def main(argv) do
     parsed = OptionParser.parse(argv, aliases: [C: :working_dir], strict: [working_dir: :string])
 
-    with {switches, [component], []} <- parsed,
-         {:ok, module} <- Map.fetch(@components, String.to_atom(component)) do
-      working_dir = Keyword.get(switches, :working_dir, File.cwd!())
-      module.main(working_dir)
-    else
-      {_, _, [_ | _]} -> usage_message()
-      {_, argv, _} when length(argv) != 1 -> usage_message()
-      :error -> usage_message()
+    case parsed do
+      {switches, [component], []} ->
+        case Map.fetch(@components, String.to_atom(component)) do
+          {:ok, module} ->
+            working_dir = Keyword.get(switches, :working_dir, File.cwd!())
+            module.main(working_dir)
+
+          :error ->
+            usage_message()
+        end
+
+      {_, _, [_ | _]} ->
+        usage_message()
+
+      {_, argv, _} when length(argv) != 1 ->
+        usage_message()
     end
   end
 


### PR DESCRIPTION
In the end, I found the `case` clause more expressive. There are three branches:

* Valid input: launch a component
* Invalid input: unknown switch
* Invalid input: wrong argument count

Having other scenarios in the future, there will be multiple shapes of valid input. E.g. the `-h`/`--help` switch would introduce a branch with a sole switch and no arguments.

The `with` clause seems to be more fitting for cases where we need to collect input from multiple sources. That is partially the case here, because we’re fetching from `@components`. Unfortunately however, I don’t see a way to add that as a `case` branch.