### PR TITLE
Valid switches with args didn’t fail

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -8,8 +8,12 @@ defmodule Onigumo.CLI do
 
     with {switches, [component], []} <- parsed,
          {:ok, module} <- Map.fetch(@components, String.to_atom(component)) do
-      working_dir = Keyword.get(switches, :working_dir, File.cwd!())
-      module.main(working_dir)
+      {working_dir, switches} = Keyword.pop(switches, :working_dir, File.cwd!())
+
+      case switches do
+        [] -> module.main(working_dir)
+        _ -> usage_message()
+      end
     else
       {_, _, [_ | _]} -> usage_message()
       {_, argv, _} when length(argv) != 1 -> usage_message()

--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -16,6 +16,7 @@ defmodule Onigumo.CLI do
               [] -> module.main(working_dir)
               _ -> usage_message()
             end
+
           :error ->
             usage_message()
         end


### PR DESCRIPTION
`Keyword.get :working_dir` doesn’t check for other switches. In the future, there may be more switches. Some of those switches may be mutually exclusive with a component name. But now, such switches would be ignored.

Imagine a help switch (`-h`/`--help`). This switch is only valid alone like `onigumo -h`. `onigumo -h downloader` or `onigumo --working-dir`. `downloader --help` are not valid. `Keyword.get` only checks for `:working_dir` though; `:help` is ignored.

`Keyword.pop` yields a keyword list of remaining switches. `:working_dir` is the only valid switch for a component. Any remaining switches mean invalid usage.

There is no way to test this: `-C` is the only valid switch. Mocking OptionParse would be an overkill: `-h` will be added soon. Then, this change can be tested.

Manual testing can be done:

1. Add `h: :help` to `OptionParser.parse` `:aliases` and `help: boolean` to `:strict`.
2. Recompile (mix escript.build) and run `./onigumo -h downloader`.
3. See the usage message printed. Downloader should not be run.

Blocks #238.