### PR TITLE
Downgrade OTP to 27 in CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -19,7 +19,7 @@ jobs:
       uses: erlef/setup-beam@v1
       with:
         elixir-version: latest
-        otp-version: latest
+        otp-version: '27'
     - name: Restore dependencies cache
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
Some dependencies don’t work with the latest OTP, which is by now [`28.0-rc2`](https://www.erlang.org/news/177). Downgrading to stable 27 fixes `mix deps.get` in the CI pipeline.

See e.g. #260 for a failing pipeline.