### PR TITLE
💚 GitHub action matrix

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Configure Git
-      run: git config core.eol lf
+      run: git config --global core.eol lf
     - name: Check out the repository
       uses: actions/checkout@v3
     - name: Set up Elixir

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Configure Git
-      run: git config --global core.eol lf
+      run: git config --global core.autocrlf false
     - name: Check out the repository
       uses: actions/checkout@v3
     - name: Set up Elixir

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Check out the repository
       uses: actions/checkout@v3
+      with:
+        config: core.eol=lf
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,7 +14,9 @@ jobs:
 
     steps:
     - name: Configure Git
-      run: git config --global core.autocrlf false
+      run: -
+        # Make line endings on Windows compatible with mix format
+        git config --global core.autocrlf false
     - name: Check out the repository
       uses: actions/checkout@v3
     - name: Set up Elixir

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+    - name: Configure Git
+      run: git config core.eol lf
     - name: Check out the repository
       uses: actions/checkout@v3
-      with:
-        config: core.eol=lf
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:


### PR DESCRIPTION
The `windows-2022` image has [`core.autocrlf`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf) set to `true`. This Git configuration replaces line endings to `\r\n`. `mix format`, however, [expects](https://hexdocs.pm/elixir/Code.html#format_string!/2-newlines) `\n`. The check then fails.

Setting `core.autocrlf` to `false` makes Git leave the newlines intact. On `ubuntu-24.01`, the value is false by default. Re-setting it does no harm.

The newline replacement happens during the clone. The setting needs to happen before. It must be global: before the clone, there is no local repository to set it to.

---

Fixes the CI error in #274.