### PR TITLE
💚  Fix CI workflow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,9 +14,8 @@ jobs:
 
     steps:
     - name: Configure Git
-      run: -
-        # Make line endings on Windows compatible with mix format
-        git config --global core.autocrlf false
+      # Make line endings on Windows compatible with mix format
+      run: git config --global core.autocrlf false
     - name: Check out the repository
       uses: actions/checkout@v3
     - name: Set up Elixir


### PR DESCRIPTION
Multiline strings are marked with `|`, not `-`. Also, moved the comment to the YAML from the bash command.