### PR TITLE
Test multiple invalid switches

### DIFF
--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -9,8 +9,8 @@ defmodule OnigumoCLITest do
   ]
 
   @invalid_switches [
-    "--invalid",
-    "-c"
+    ["--invalid"],
+    ["-c"]
   ]
 
   @invalid_combinations [
@@ -44,9 +44,9 @@ defmodule OnigumoCLITest do
       assert usage_message_printed?(fn -> Onigumo.CLI.main(["Downloader", "Parser"]) end)
     end
 
-    for switch <- @invalid_switches do
-      test("run CLI with invalid switch #{inspect(switch)}") do
-        assert usage_message_printed?(fn -> Onigumo.CLI.main([unquote(switch)]) end)
+    for switches <- @invalid_switches do
+      test("run CLI with invalid switches #{inspect(switches)}") do
+        assert usage_message_printed?(fn -> Onigumo.CLI.main(unquote(switches)) end)
       end
     end
 

--- a/test/onigumo_cli_test.exs
+++ b/test/onigumo_cli_test.exs
@@ -10,7 +10,8 @@ defmodule OnigumoCLITest do
 
   @invalid_switches [
     ["--invalid"],
-    ["-c"]
+    ["-c"],
+    ["--invalid", "-c"]
   ]
 
   @invalid_combinations [


### PR DESCRIPTION
The tests parametrization using `@invalid_switches` can only test a single invalid switch. It is not possible to test for multiple invalid switches. Turned the parametrization list elements into lists. Now when `@invalid_switches` parameterization elements are lists, it is possible to test multiple invalid switches.

Fixes #279.