### PR TITLE
Remove guard from more arugments

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -41,7 +41,7 @@ defmodule Onigumo.CLI do
         |> then(&"invalid OPTIONS #{&1}")
         |> usage_message()
 
-      {_, argv, _} when length(argv) != 1 ->
+      {_, _, _} ->
         usage_message("exactly one COMPONENT must be provided")
     end
   end


### PR DESCRIPTION
The length guard for arguments was redundant. The other case (exactly one positional argument) is laredy covered by previous case branches. The reasoning described in more detail in https://github.com/Glutexo/onigumo/issues/278.

Fixes https://github.com/Glutexo/onigumo/issues/278.