### PR TITLE
Match empty invalid in CLI

### DIFF
--- a/lib/cli.ex
+++ b/lib/cli.ex
@@ -41,7 +41,7 @@ defmodule Onigumo.CLI do
         |> then(&"invalid OPTIONS #{&1}")
         |> usage_message()
 
-      {_, argv, _} when length(argv) != 1 ->
+      {_, argv, []} when length(argv) != 1 ->
         usage_message("exactly one COMPONENT must be provided")
     end
   end


### PR DESCRIPTION
The more than one component error branch always matches an empty invalid list. Mentioning it explicitly to make the match precise: preventing an invalid switch value to be falsely masked as more than one argument error.

Related to #282.